### PR TITLE
Added manifest changes to enable nnhal 1.3

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -104,7 +104,9 @@ cc_library_shared {
 
     defaults: [
         "neuralnetworks_defaults"
-    ]
+    ],
+
+    vintf_fragments: ["android.hardware.neuralnetworks@1.3.xml"]
 
 }
 

--- a/android.hardware.neuralnetworks@1.3.xml
+++ b/android.hardware.neuralnetworks@1.3.xml
@@ -1,0 +1,11 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>android.hardware.neuralnetworks</name>
+        <transport>hwbinder</transport>
+        <version>1.3</version>
+        <interface>
+            <name>IDevice</name>
+            <instance>CPU</instance>
+        </interface>
+    </hal>
+</manifest>


### PR DESCRIPTION
moved manifest changes which enable nnhal within
nnhal. Thus to disable nnhal one needs to modify
only mixin.spec, by setting neuralnetworks: false

Change-Id: I79ec230dad1ab2f919a097d4db7a3865d7f91e11
Tracked-On: OAM-103820
Signed-off-by: Ratnesh Kumar Rai <ratnesh.kumar.rai@intel.com>