### PR TITLE
Enable operations required for object detection

### DIFF
--- a/ngraph_creator/operations/include/DepthToSpace.hpp
+++ b/ngraph_creator/operations/include/DepthToSpace.hpp
@@ -10,6 +10,7 @@ namespace nnhal {
 class DepthToSpace : public OperationsBase {
 public:
     DepthToSpace(int operationIndex);
+    bool validate() override;
     std::shared_ptr<ngraph::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/src/Add.cpp
+++ b/ngraph_creator/operations/src/Add.cpp
@@ -20,14 +20,6 @@ bool Add::validate() {
          ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
          return false;
     }
-    //check operand lifetime
-    const auto& operandIndex3 = sModelInfo->getOperationInput(mNnapiOperationIndex, 2);
-    if(!sModelInfo->isOperandLifeTimeConst(operandIndex1) ||
-        !sModelInfo->isOperandLifeTimeConst(operandIndex2) ||
-        !sModelInfo->isOperandLifeTimeConst(operandIndex3)) {
-        ALOGE("%s Only Const lifetime is supported", __func__);
-        return false;
-    }
 
     // check if both tensors are of same type
     if(elementType1 != elementType2 ) {

--- a/ngraph_creator/operations/src/DepthToSpace.cpp
+++ b/ngraph_creator/operations/src/DepthToSpace.cpp
@@ -11,6 +11,30 @@ DepthToSpace::DepthToSpace(int operationIndex) : OperationsBase(operationIndex) 
     mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
+bool DepthToSpace::validate() {
+    // Check input rank
+    const auto inputRank = getInputOperandDimensions(0).size();
+
+    if (inputRank != 4) {
+        ALOGE("%s Invalid dimension of rank %d", __func__, inputRank);
+        return false;
+    }
+
+    if ( !isValidInputTensor(0)) {
+         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
+         return false;
+    }
+
+    auto block_size = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 1);
+    if(block_size < 1) {
+        ALOGE("%s Invalid block size %d", __func__, block_size);
+        return false;
+    }
+
+    ALOGV("%s PASSED", __func__);
+    return true;
+}
+
 std::shared_ptr<ngraph::Node> DepthToSpace::createNode() {
     // Creating input nodes
     std::shared_ptr<ngraph::Node> input;

--- a/ngraph_creator/operations/src/Div.cpp
+++ b/ngraph_creator/operations/src/Div.cpp
@@ -20,14 +20,6 @@ bool Div::validate() {
          ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
          return false;
     }
-    //check operand lifetime
-    const auto& operandIndex3 = sModelInfo->getOperationInput(mNnapiOperationIndex, 2);
-    if(!sModelInfo->isOperandLifeTimeConst(operandIndex1) ||
-        !sModelInfo->isOperandLifeTimeConst(operandIndex2) ||
-        !sModelInfo->isOperandLifeTimeConst(operandIndex3)) {
-        ALOGE("%s Only Const lifetime is supported", __func__);
-        return false;
-    }
 
     // check if both tensors are of same type
     if(elementType1 != elementType2 ) {

--- a/ngraph_creator/operations/src/Less.cpp
+++ b/ngraph_creator/operations/src/Less.cpp
@@ -20,12 +20,6 @@ bool Less::validate() {
          ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
          return false;
     }
-    //check operand lifetime
-    if(!sModelInfo->isOperandLifeTimeConst(operandIndex1) ||
-        !sModelInfo->isOperandLifeTimeConst(operandIndex2)) {
-        ALOGE("%s Only Const lifetime is supported", __func__);
-        return false;
-    }
 
     // check if both tensors are of same type
     if(elementType1 != elementType2 ) {

--- a/ngraph_creator/operations/src/Mul.cpp
+++ b/ngraph_creator/operations/src/Mul.cpp
@@ -12,8 +12,6 @@ Mul::Mul(int operationIndex) : OperationsBase(operationIndex) {
 }
 
 bool Mul::validate() {
-    const auto inputRank1 = getInputOperandDimensions(0).size();
-    const auto inputRank2 = getInputOperandDimensions(1).size();
     auto operandIndex1 = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
     auto operandIndex2 = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
     const auto& elementType1 = sModelInfo->getOperandType(operandIndex1);
@@ -22,15 +20,6 @@ bool Mul::validate() {
     if ( !isValidInputTensor(0) || !isValidInputTensor(1) ) {
          ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
          return false;
-    }
-
-    //check operand lifetime
-    const auto& operandIndex3 = sModelInfo->getOperationInput(mNnapiOperationIndex, 2);
-    if(!sModelInfo->isOperandLifeTimeConst(operandIndex1) ||
-        !sModelInfo->isOperandLifeTimeConst(operandIndex2) ||
-        !sModelInfo->isOperandLifeTimeConst(operandIndex3)) {
-        ALOGE("%s Only Const lifetime is supported", __func__);
-        return false;
     }
 
     if(elementType1 != elementType2 ) {

--- a/ngraph_creator/operations/src/OperationsBase.cpp
+++ b/ngraph_creator/operations/src/OperationsBase.cpp
@@ -109,7 +109,7 @@ bool OperationsBase::checkOperandType(uint32_t operandIndex, const int32_t expec
                                       const std::string& strLogInfo) {
     const auto operandType = (int32_t)sModelInfo->getOperandType(operandIndex);
     if (operandType != expectedOperandType) {
-        ALOGE("OperationIndex %d %s Index %d type %d invalid", mNnapiOperationIndex,
+        ALOGV("OperationIndex %d %s Index %d type %d invalid", mNnapiOperationIndex,
               strLogInfo.c_str(), operandIndex, operandType);
         return false;
     }

--- a/ngraph_creator/operations/src/ReduceMin.cpp
+++ b/ngraph_creator/operations/src/ReduceMin.cpp
@@ -26,13 +26,6 @@ bool ReduceMin::validate() {
     auto& input_OperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
     auto& dim_reduce_OperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
 
-    // TODO: Add Support for all_tensors_as_inputs
-    if (!sModelInfo->isOperandLifeTimeConst(input_OperandIndex) ||
-        !sModelInfo->isOperandLifeTimeConst(dim_reduce_OperandIndex)) {
-        ALOGE("%s Only Constant dimensions supported now", __func__);
-        return false;
-    }
-
     ALOGV("%s PASSED", __func__);
     return true;
 }

--- a/ngraph_creator/operations/src/ReduceSum.cpp
+++ b/ngraph_creator/operations/src/ReduceSum.cpp
@@ -26,13 +26,6 @@ bool ReduceSum::validate() {
     auto& input_OperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
     auto& dim_reduce_OperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
 
-    // TODO: Add Support for all_tensors_as_inputs
-    if (!sModelInfo->isOperandLifeTimeConst(input_OperandIndex) ||
-        !sModelInfo->isOperandLifeTimeConst(dim_reduce_OperandIndex)) {
-        ALOGE("%s Only Constant dimensions supported now", __func__);
-        return false;
-    }
-
     ALOGV("%s PASSED", __func__);
     return true;
 }

--- a/ngraph_creator/operations/src/Relu.cpp
+++ b/ngraph_creator/operations/src/Relu.cpp
@@ -16,12 +16,6 @@ bool Relu::validate() {
          ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
          return false;
     }
-    //check operand lifetime
-    const auto& dimsOperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
-    if(!sModelInfo->isOperandLifeTimeConst(dimsOperandIndex)) {
-        ALOGE("%s Only Const lifetime is supported", __func__);
-        return false;
-    }
 
     ALOGV("%s PASSED", __func__);
     return true;

--- a/ngraph_creator/operations/src/Relu1.cpp
+++ b/ngraph_creator/operations/src/Relu1.cpp
@@ -16,12 +16,6 @@ bool Relu1::validate() {
          ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
          return false;
     }
-    //check operand lifetime
-    const auto& dimsOperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
-    if(!sModelInfo->isOperandLifeTimeConst(dimsOperandIndex)) {
-        ALOGE("%s Only Const lifetime is supported", __func__);
-        return false;
-    }
 
     ALOGV("%s PASSED", __func__);
     return true;

--- a/ngraph_creator/operations/src/Relu6.cpp
+++ b/ngraph_creator/operations/src/Relu6.cpp
@@ -16,12 +16,6 @@ bool Relu6::validate() {
          ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
          return false;
     }
-    //check operand lifetime
-    const auto& dimsOperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
-    if(!sModelInfo->isOperandLifeTimeConst(dimsOperandIndex)) {
-        ALOGE("%s Only Const lifetime is supported", __func__);
-        return false;
-    }
 
     ALOGV("%s PASSED", __func__);
     return true;

--- a/ngraph_creator/operations/src/Reshape.cpp
+++ b/ngraph_creator/operations/src/Reshape.cpp
@@ -12,12 +12,17 @@ Reshape::Reshape(int operationIndex) : OperationsBase(operationIndex) {
 }
 
 bool Reshape::validate() {
-    const auto& dimsOperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
-    if (!sModelInfo->isOperandLifeTimeConst(dimsOperandIndex) || !isValidInputTensor(1)) {
-        // TODO: Support CPU_reshape_all_tensors_as_inputs
-        ALOGE("%s Only Constant non-zero dimensions supported now", __func__);
+    const auto inputRank = getInputOperandDimensions(0).size();
+    if (!isValidInputTensor(0)) {
+        ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
         return false;
     }
+
+    if (inputRank > 4) {
+         ALOGE("%s Invalid dimensions size for input", __func__);
+         return false;
+    }
+
     ALOGV("%s PASSED", __func__);
     return true;
 }

--- a/ngraph_creator/operations/src/Sub.cpp
+++ b/ngraph_creator/operations/src/Sub.cpp
@@ -20,14 +20,7 @@ bool Sub::validate() {
          ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
          return false;
     }
-    //check operand lifetime
-    const auto& operandIndex3 = sModelInfo->getOperationInput(mNnapiOperationIndex, 2);
-    if(!sModelInfo->isOperandLifeTimeConst(operandIndex1) ||
-        !sModelInfo->isOperandLifeTimeConst(operandIndex2) ||
-        !sModelInfo->isOperandLifeTimeConst(operandIndex3)) {
-        ALOGE("%s Only Const lifetime is supported", __func__);
-        return false;
-    }
+
     // check if both tensors are of same type
     if(elementType1 != elementType2 ) {
         ALOGE("%s Input type mismatch", __func__);

--- a/ngraph_creator/operations/src/Transpose.cpp
+++ b/ngraph_creator/operations/src/Transpose.cpp
@@ -20,11 +20,6 @@ bool Transpose::validate() {
          return false;
     }
 
-    if(!sModelInfo->isOperandLifeTimeConst(dimsOperandIndex1)) {
-        ALOGE("%s Only Const lifetime is supported", __func__);
-        return false;
-    }
-
     const auto& inputsSize = sModelInfo->getOperationInputsSize(mNnapiOperationIndex);
     if (inputsSize == 2) {
         const auto& dimsOperandIndex2 = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);

--- a/ngraph_creator/src/OperationsFactory.cpp
+++ b/ngraph_creator/src/OperationsFactory.cpp
@@ -38,12 +38,12 @@ std::shared_ptr<OperationsBase> OperationsFactory::getOperation(
             return std::make_shared<ChannelShuffle>(operationIndex);
         case OperationType::CONCATENATION:
             return std::make_shared<Concat>(operationIndex);
-        // case OperationType::CONV_2D:
-        //     return std::make_shared<Conv2d>(operationIndex);
+        case OperationType::CONV_2D:
+            return std::make_shared<Conv2d>(operationIndex);
         case OperationType::DEPTH_TO_SPACE:
             return std::make_shared<DepthToSpace>(operationIndex);
-        // case OperationType::DEPTHWISE_CONV_2D:
-        //     return std::make_shared<DepthwiseConv2d>(operationIndex);
+        case OperationType::DEPTHWISE_CONV_2D:
+            return std::make_shared<DepthwiseConv2d>(operationIndex);
         case OperationType::DEQUANTIZE:
             return std::make_shared<Dequantize>(operationIndex);
         case OperationType::DIV:
@@ -94,8 +94,8 @@ std::shared_ptr<OperationsBase> OperationsFactory::getOperation(
             return std::make_shared<Logistic>(operationIndex);
         case OperationType::MAXIMUM:
             return std::make_shared<Maximum>(operationIndex);
-        // case OperationType::MAX_POOL_2D:
-        //     return std::make_shared<MaxPool2d>(operationIndex);
+        case OperationType::MAX_POOL_2D:
+            return std::make_shared<MaxPool2d>(operationIndex);
         case OperationType::MEAN:
             return std::make_shared<Mean>(operationIndex);
         case OperationType::MINIMUM:


### PR DESCRIPTION
This commit reverts the disabled ops and const life operand check for the operations required for object detection

Also validation check is added for DepthToSpace op

Change-Id: I87da230dad1ab2f919a097d4db7a3865d7f91e11
Tracked-On: OAM-104082
Signed-off-by: Ratnesh Kumar Rai <ratnesh.kumar.rai@intel.com>