### PR TITLE
Re-enable Operations that were disabled due to CTS errors

### DIFF
--- a/ngraph_creator/operations/include/DepthToSpace.hpp
+++ b/ngraph_creator/operations/include/DepthToSpace.hpp
@@ -10,7 +10,6 @@ namespace nnhal {
 class DepthToSpace : public OperationsBase {
 public:
     DepthToSpace(int operationIndex);
-    bool validate() override;
     std::shared_ptr<ngraph::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Dequantize.hpp
+++ b/ngraph_creator/operations/include/Dequantize.hpp
@@ -11,7 +11,6 @@ class Dequantize : public OperationsBase {
 public:
     Dequantize(int operationIndex);
     std::shared_ptr<ngraph::Node> createNode() override;
-    bool validate() override;
 };
 
 }  // namespace nnhal

--- a/ngraph_creator/operations/include/Div.hpp
+++ b/ngraph_creator/operations/include/Div.hpp
@@ -10,7 +10,6 @@ namespace nnhal {
 class Div : public OperationsBase {
 public:
     Div(int operationIndex);
-    bool validate() override;
     std::shared_ptr<ngraph::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/L2Pooling2D.hpp
+++ b/ngraph_creator/operations/include/L2Pooling2D.hpp
@@ -10,7 +10,6 @@ namespace nnhal {
 class L2Pooling2D : public OperationsBase {
 public:
     L2Pooling2D(int operationIndex);
-     bool validate() override;
     std::shared_ptr<ngraph::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Less.hpp
+++ b/ngraph_creator/operations/include/Less.hpp
@@ -10,7 +10,6 @@ namespace nnhal {
 class Less : public OperationsBase {
 public:
     Less(int operationIndex);
-    bool validate() override;
     std::shared_ptr<ngraph::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Logistic.hpp
+++ b/ngraph_creator/operations/include/Logistic.hpp
@@ -10,7 +10,6 @@ namespace nnhal {
 class Logistic : public OperationsBase {
 public:
     Logistic(int operationIndex);
-    bool validate() override;
     std::shared_ptr<ngraph::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/MaxPool2d.hpp
+++ b/ngraph_creator/operations/include/MaxPool2d.hpp
@@ -10,7 +10,6 @@ namespace nnhal {
 class MaxPool2d : public OperationsBase {
 public:
     MaxPool2d(int operationIndex);
-    bool validate() override;
     std::shared_ptr<ngraph::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Mul.hpp
+++ b/ngraph_creator/operations/include/Mul.hpp
@@ -10,7 +10,6 @@ namespace nnhal {
 class Mul : public OperationsBase {
 public:
     Mul(int operationIndex);
-    bool validate() override;
     std::shared_ptr<ngraph::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Quantize.hpp
+++ b/ngraph_creator/operations/include/Quantize.hpp
@@ -11,7 +11,6 @@ class Quantize : public OperationsBase {
 public:
     Quantize(int operationIndex);
     std::shared_ptr<ngraph::Node> createNode() override;
-    bool validate() override;
     void connectOperationToGraph() override;
 };
 

--- a/ngraph_creator/operations/include/ReduceMin.hpp
+++ b/ngraph_creator/operations/include/ReduceMin.hpp
@@ -10,7 +10,6 @@ namespace nnhal {
 class ReduceMin : public OperationsBase {
 public:
     ReduceMin(int operationIndex);
-    bool validate() override;
     std::shared_ptr<ngraph::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/ReduceSum.hpp
+++ b/ngraph_creator/operations/include/ReduceSum.hpp
@@ -10,7 +10,6 @@ namespace nnhal {
 class ReduceSum : public OperationsBase {
 public:
     ReduceSum(int operationIndex);
-    bool validate() override;
     std::shared_ptr<ngraph::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Relu.hpp
+++ b/ngraph_creator/operations/include/Relu.hpp
@@ -10,7 +10,6 @@ namespace nnhal {
 class Relu : public OperationsBase {
 public:
     Relu(int operationIndex);
-    bool validate() override;
     std::shared_ptr<ngraph::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Relu1.hpp
+++ b/ngraph_creator/operations/include/Relu1.hpp
@@ -10,7 +10,6 @@ namespace nnhal {
 class Relu1 : public OperationsBase {
 public:
     Relu1(int operationIndex);
-    bool validate() override;
     std::shared_ptr<ngraph::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Relu6.hpp
+++ b/ngraph_creator/operations/include/Relu6.hpp
@@ -10,7 +10,6 @@ namespace nnhal {
 class Relu6 : public OperationsBase {
 public:
     Relu6(int operationIndex);
-    bool validate() override;
     std::shared_ptr<ngraph::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Softmax.hpp
+++ b/ngraph_creator/operations/include/Softmax.hpp
@@ -10,7 +10,6 @@ namespace nnhal {
 class Softmax : public OperationsBase {
 public:
     Softmax(int operationIndex);
-    bool validate() override;
     std::shared_ptr<ngraph::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Sub.hpp
+++ b/ngraph_creator/operations/include/Sub.hpp
@@ -10,7 +10,6 @@ namespace nnhal {
 class Sub : public OperationsBase {
 public:
     Sub(int operationIndex);
-    bool validate() override;
     std::shared_ptr<ngraph::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Tanh.hpp
+++ b/ngraph_creator/operations/include/Tanh.hpp
@@ -10,7 +10,6 @@ namespace nnhal {
 class Tanh : public OperationsBase {
 public:
     Tanh(int operationIndex);
-    bool validate() override;
     std::shared_ptr<ngraph::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/src/Add.cpp
+++ b/ngraph_creator/operations/src/Add.cpp
@@ -12,29 +12,14 @@ Add::Add(int operationIndex) : OperationsBase(operationIndex) {
 }
 
 bool Add::validate() {
-    auto operandIndex1 = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
-    auto operandIndex2 = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
-    const auto& elementType1 = sModelInfo->getOperandType(operandIndex1);
-    const auto& elementType2 = sModelInfo->getOperandType(operandIndex2);
-    if ( !isValidInputTensor(0) || !isValidInputTensor(1) ) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
+    ALOGV("%s PASSED", __func__);
+
+    const auto& activationIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+    if (!sModelInfo->isOperandLifeTimeConst(activationIndex)) {
+        ALOGE("%s Only Constant supported for specifying Activation", __func__);
+        return false;
     }
 
-    // check if both tensors are of same type
-    if(elementType1 != elementType2 ) {
-        ALOGE("%s Input type mismatch", __func__);
-        return false;
-    } else if ( elementType1 == OperandType::TENSOR_INT32 ) {
-        //In 1.3 For a {@link OperandType::TENSOR_INT32} tensor,
-        //the {@link FusedActivationFunc} must be "NONE".
-        auto activationFn = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
-        if (activationFn != 0) {
-             ALOGE("%s Activation type must be none for TENSOR_INT32 type", __func__);
-            return false;
-        }
-    }
-    ALOGV("%s PASSED", __func__);
     return true;
 }
 

--- a/ngraph_creator/operations/src/AveragePool2D.cpp
+++ b/ngraph_creator/operations/src/AveragePool2D.cpp
@@ -18,11 +18,6 @@ bool AveragePool2D::validate() {
         ALOGE("%s Invalid dimensions size for input(%lu)", __func__, inputDimensionsSize);
         return false;
     }
-    //check Input are of valid dimension or not
-    if ( !isValidInputTensor(0)) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
-    }
 
     ALOGV("%s PASSED", __func__);
     return true;

--- a/ngraph_creator/operations/src/DepthToSpace.cpp
+++ b/ngraph_creator/operations/src/DepthToSpace.cpp
@@ -11,30 +11,6 @@ DepthToSpace::DepthToSpace(int operationIndex) : OperationsBase(operationIndex) 
     mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
-bool DepthToSpace::validate() {
-    // Check input rank
-    const auto inputRank = getInputOperandDimensions(0).size();
-
-    if (inputRank != 4) {
-        ALOGE("%s Invalid dimension of rank %d", __func__, inputRank);
-        return false;
-    }
-
-    if ( !isValidInputTensor(0)) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
-    }
-
-    auto block_size = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 1);
-    if(block_size < 1) {
-        ALOGE("%s Invalid block size %d", __func__, block_size);
-        return false;
-    }
-
-    ALOGV("%s PASSED", __func__);
-    return true;
-}
-
 std::shared_ptr<ngraph::Node> DepthToSpace::createNode() {
     // Creating input nodes
     std::shared_ptr<ngraph::Node> input;

--- a/ngraph_creator/operations/src/Dequantize.cpp
+++ b/ngraph_creator/operations/src/Dequantize.cpp
@@ -11,16 +11,6 @@ Dequantize::Dequantize(int operationIndex) : OperationsBase(operationIndex) {
     mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
-bool Dequantize::validate() {
-    if ( !isValidInputTensor(0)) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
-    }
-
-    ALOGV("%s PASSED", __func__);
-    return true;
-}
-
 std::shared_ptr<ngraph::Node> Dequantize::createNode() {
     // Creating input nodes
     std::shared_ptr<ngraph::Node> input, outputNode;

--- a/ngraph_creator/operations/src/Div.cpp
+++ b/ngraph_creator/operations/src/Div.cpp
@@ -11,33 +11,6 @@ Div::Div(int operationIndex) : OperationsBase(operationIndex) {
     mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
-bool Div::validate() {
-    auto operandIndex1 = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
-    auto operandIndex2 = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
-    const auto& elementType1 = sModelInfo->getOperandType(operandIndex1);
-    const auto& elementType2 = sModelInfo->getOperandType(operandIndex2);
-    if ( !isValidInputTensor(0) || !isValidInputTensor(1) ) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
-    }
-
-    // check if both tensors are of same type
-    if(elementType1 != elementType2 ) {
-        ALOGE("%s Input type mismatch", __func__);
-        return false;
-    } else if ( elementType1 == OperandType::TENSOR_INT32 ) {
-        //In 1.3 For a {@link OperandType::TENSOR_INT32} tensor,
-        //the {@link FusedActivationFunc} must be "NONE".
-        auto activationFn = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
-        if (activationFn != 0) {
-             ALOGE("%s Activation type must be none for TENSOR_INT32 type", __func__);
-            return false;
-        }
-    }
-    ALOGV("%s PASSED", __func__);
-    return true;
-}
-
 std::shared_ptr<ngraph::Node> Div::createNode() {
     // Creating input nodes
     auto input1 = getInputNode(0);

--- a/ngraph_creator/operations/src/FullyConnected.cpp
+++ b/ngraph_creator/operations/src/FullyConnected.cpp
@@ -25,18 +25,6 @@ bool FullyConnected::validate() {
         ALOGE("%s Invalid input parameter dimensions!!!", __func__);
         return false;
     }
-    //check operand lifetime
-    const auto& dimsOperandIndex1 = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
-    const auto& dimsOperandIndex2 = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
-    const auto& dimsOperandIndex3 = sModelInfo->getOperationInput(mNnapiOperationIndex, 2);
-    const auto& dimsOperandIndex4 = sModelInfo->getOperationInput(mNnapiOperationIndex, 3);
-    if(!sModelInfo->isOperandLifeTimeConst(dimsOperandIndex1) ||
-        !sModelInfo->isOperandLifeTimeConst(dimsOperandIndex2) ||
-        !sModelInfo->isOperandLifeTimeConst(dimsOperandIndex3) ||
-        !sModelInfo->isOperandLifeTimeConst(dimsOperandIndex4)) {
-        ALOGE("%s Only Const lifetime is supported", __func__);
-        return false;
-    }
 
     ALOGD("%s succeeded", __func__);
     return true;

--- a/ngraph_creator/operations/src/L2Pooling2D.cpp
+++ b/ngraph_creator/operations/src/L2Pooling2D.cpp
@@ -11,22 +11,6 @@ L2Pooling2D::L2Pooling2D(int operationIndex) : OperationsBase(operationIndex) {
     mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
-bool L2Pooling2D::validate() {
-    const auto& inputDimensionsSize = getInputOperandDimensions(0).size();
-    if (inputDimensionsSize != 4) {
-        ALOGE("%s Invalid dimensions size for input(%lu)", __func__, inputDimensionsSize);
-        return false;
-    }
-    //check Input are of valid dimension or not
-    if ( !isValidInputTensor(0)) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
-    }
-
-    ALOGV("%s PASSED", __func__);
-    return true;
-}
-
 std::shared_ptr<ngraph::Node> L2Pooling2D::createNode() {
     const auto& inputsSize = sModelInfo->getOperationInputsSize(mNnapiOperationIndex);
     bool isImplicit = false, isExplicit = false;

--- a/ngraph_creator/operations/src/Less.cpp
+++ b/ngraph_creator/operations/src/Less.cpp
@@ -11,25 +11,6 @@ Less::Less(int operationIndex) : OperationsBase(operationIndex) {
     mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
-bool Less::validate() {
-    auto operandIndex1 = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
-    auto operandIndex2 = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
-    const auto& elementType1 = sModelInfo->getOperandType(operandIndex1);
-    const auto& elementType2 = sModelInfo->getOperandType(operandIndex2);
-    if ( !isValidInputTensor(0) || !isValidInputTensor(1) ) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
-    }
-
-    // check if both tensors are of same type
-    if(elementType1 != elementType2 ) {
-        ALOGE("%s Input type mismatch", __func__);
-        return false;
-    }
-
-    ALOGV("%s PASSED", __func__);
-    return true;
-}
 std::shared_ptr<ngraph::Node> Less::createNode() {
     // Creating input nodes
     std::shared_ptr<ngraph::Node> input1, input2;

--- a/ngraph_creator/operations/src/Logistic.cpp
+++ b/ngraph_creator/operations/src/Logistic.cpp
@@ -11,22 +11,6 @@ Logistic::Logistic(int operationIndex) : OperationsBase(operationIndex) {
     mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
-bool Logistic::validate() {
-    const auto& inputDimensionsSize = getInputOperandDimensions(0).size();
-    if (inputDimensionsSize > 4) {
-        ALOGE("%s Invalid dimensions size for input(%lu)", __func__, inputDimensionsSize);
-        return false;
-    }
-    //check Input are of valid dimension or not
-    if ( !isValidInputTensor(0)) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
-    }
-
-    ALOGV("%s PASSED", __func__);
-    return true;
-}
-
 std::shared_ptr<ngraph::Node> Logistic::createNode() {
     // Creating input nodes
     std::shared_ptr<ngraph::Node> input;

--- a/ngraph_creator/operations/src/MaxPool2d.cpp
+++ b/ngraph_creator/operations/src/MaxPool2d.cpp
@@ -11,22 +11,6 @@ MaxPool2d::MaxPool2d(int operationIndex) : OperationsBase(operationIndex) {
     mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
-bool MaxPool2d::validate() {
-    // Check Input Dimension size
-    const auto& inputDimensionsSize = getInputOperandDimensions(0).size();
-    if (inputDimensionsSize != 4) {
-        ALOGE("%s Invalid dimensions size for input(%lu)", __func__, inputDimensionsSize);
-        return false;
-    }
-    //check Input are of valid dimension or not
-    if ( !isValidInputTensor(0)) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
-    }
-
-    ALOGV("%s PASSED", __func__);
-    return true;
-}
 std::shared_ptr<ngraph::Node> MaxPool2d::createNode() {
     const auto& inputsSize = sModelInfo->getOperationInputsSize(mNnapiOperationIndex);
     ALOGD("%s inputsSize %lu", __func__, inputsSize);

--- a/ngraph_creator/operations/src/Mul.cpp
+++ b/ngraph_creator/operations/src/Mul.cpp
@@ -11,34 +11,6 @@ Mul::Mul(int operationIndex) : OperationsBase(operationIndex) {
     mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
-bool Mul::validate() {
-    auto operandIndex1 = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
-    auto operandIndex2 = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
-    const auto& elementType1 = sModelInfo->getOperandType(operandIndex1);
-    const auto& elementType2 = sModelInfo->getOperandType(operandIndex2);
-
-    if ( !isValidInputTensor(0) || !isValidInputTensor(1) ) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
-    }
-
-    if(elementType1 != elementType2 ) {
-        ALOGE("%s Input type mismatch", __func__);
-        return false;
-    } else if ( elementType1 == OperandType::TENSOR_INT32 ) {
-        //In 1.3 For a {@link OperandType::TENSOR_INT32} tensor,
-        //the {@link FusedActivationFunc} must be "NONE".
-        auto activationFn = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
-        if (activationFn != 0) {
-             ALOGE("%s Activation type must be none for TENSOR_INT32 type", __func__);
-            return false;
-        }
-    }
-
-    ALOGV("%s PASSED", __func__);
-    return true;
-}
-
 std::shared_ptr<ngraph::Node> Mul::createNode() {
     // Creating input nodes
     std::shared_ptr<ngraph::Node> input1, input2;

--- a/ngraph_creator/operations/src/OperationsBase.cpp
+++ b/ngraph_creator/operations/src/OperationsBase.cpp
@@ -109,7 +109,7 @@ bool OperationsBase::checkOperandType(uint32_t operandIndex, const int32_t expec
                                       const std::string& strLogInfo) {
     const auto operandType = (int32_t)sModelInfo->getOperandType(operandIndex);
     if (operandType != expectedOperandType) {
-        ALOGV("OperationIndex %d %s Index %d type %d invalid", mNnapiOperationIndex,
+        ALOGE("OperationIndex %d %s Index %d type %d invalid", mNnapiOperationIndex,
               strLogInfo.c_str(), operandIndex, operandType);
         return false;
     }

--- a/ngraph_creator/operations/src/Quantize.cpp
+++ b/ngraph_creator/operations/src/Quantize.cpp
@@ -11,16 +11,6 @@ Quantize::Quantize(int operationIndex) : OperationsBase(operationIndex) {
     mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
-bool Quantize::validate() {
-    if ( !isValidInputTensor(0)) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
-    }
-
-    ALOGV("%s PASSED", __func__);
-    return true;
-}
-
 void Quantize::connectOperationToGraph() { createNode(); }
 
 std::shared_ptr<ngraph::Node> Quantize::createNode() {

--- a/ngraph_creator/operations/src/ReduceMin.cpp
+++ b/ngraph_creator/operations/src/ReduceMin.cpp
@@ -11,25 +11,6 @@ ReduceMin::ReduceMin(int operationIndex) : OperationsBase(operationIndex) {
     mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
-bool ReduceMin::validate() {
-    // Check input rank
-    const auto inputRank = getInputOperandDimensions(0).size();
-
-    if (inputRank > 4) 
-        return false;
-
-    if ( !isValidInputTensor(0) || !isValidInputTensor(1)) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
-    }
-
-    auto& input_OperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
-    auto& dim_reduce_OperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
-
-    ALOGV("%s PASSED", __func__);
-    return true;
-}
-
 std::shared_ptr<ngraph::Node> ReduceMin::createNode() {
     // Creating input nodes
     std::shared_ptr<ngraph::Node> input;

--- a/ngraph_creator/operations/src/ReduceSum.cpp
+++ b/ngraph_creator/operations/src/ReduceSum.cpp
@@ -11,25 +11,6 @@ ReduceSum::ReduceSum(int operationIndex) : OperationsBase(operationIndex) {
     mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
-bool ReduceSum::validate() {
-    // Check input rank
-    const auto inputRank = getInputOperandDimensions(0).size();
-
-    if (inputRank > 4)
-        return false;
-
-    if ( !isValidInputTensor(0) || !isValidInputTensor(1)) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
-    }
-
-    auto& input_OperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
-    auto& dim_reduce_OperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
-
-    ALOGV("%s PASSED", __func__);
-    return true;
-}
-
 std::shared_ptr<ngraph::Node> ReduceSum::createNode() {
     // Creating input nodes
     auto input = getInputNode(0);

--- a/ngraph_creator/operations/src/Relu.cpp
+++ b/ngraph_creator/operations/src/Relu.cpp
@@ -11,16 +11,6 @@ Relu::Relu(int operationIndex) : OperationsBase(operationIndex) {
     mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
-bool Relu::validate() {
-    if ( !isValidInputTensor(0)) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
-    }
-
-    ALOGV("%s PASSED", __func__);
-    return true;
-}
-
 std::shared_ptr<ngraph::Node> Relu::createNode() {
     // Creating input nodes
     std::shared_ptr<ngraph::Node> input;

--- a/ngraph_creator/operations/src/Relu1.cpp
+++ b/ngraph_creator/operations/src/Relu1.cpp
@@ -11,16 +11,6 @@ Relu1::Relu1(int operationIndex) : OperationsBase(operationIndex) {
     mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
-bool Relu1::validate() {
-    if ( !isValidInputTensor(0)) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
-    }
-
-    ALOGV("%s PASSED", __func__);
-    return true;
-}
-
 std::shared_ptr<ngraph::Node> Relu1::createNode() {
     // Creating input nodes
     std::shared_ptr<ngraph::Node> input;

--- a/ngraph_creator/operations/src/Relu6.cpp
+++ b/ngraph_creator/operations/src/Relu6.cpp
@@ -11,16 +11,6 @@ Relu6::Relu6(int operationIndex) : OperationsBase(operationIndex) {
     mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
-bool Relu6::validate() {
-    if ( !isValidInputTensor(0)) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
-    }
-
-    ALOGV("%s PASSED", __func__);
-    return true;
-}
-
 std::shared_ptr<ngraph::Node> Relu6::createNode() {
     // Creating input nodes
     std::shared_ptr<ngraph::Node> input;

--- a/ngraph_creator/operations/src/Reshape.cpp
+++ b/ngraph_creator/operations/src/Reshape.cpp
@@ -12,17 +12,12 @@ Reshape::Reshape(int operationIndex) : OperationsBase(operationIndex) {
 }
 
 bool Reshape::validate() {
-    const auto inputRank = getInputOperandDimensions(0).size();
-    if (!isValidInputTensor(0)) {
-        ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
+    const auto& dimsOperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+    if (!sModelInfo->isOperandLifeTimeConst(dimsOperandIndex) || !isValidInputTensor(1)) {
+        // TODO: Support CPU_reshape_all_tensors_as_inputs
+        ALOGE("%s Only Constant non-zero dimensions supported now", __func__);
         return false;
     }
-
-    if (inputRank > 4) {
-         ALOGE("%s Invalid dimensions size for input", __func__);
-         return false;
-    }
-
     ALOGV("%s PASSED", __func__);
     return true;
 }

--- a/ngraph_creator/operations/src/Softmax.cpp
+++ b/ngraph_creator/operations/src/Softmax.cpp
@@ -11,17 +11,6 @@ Softmax::Softmax(int operationIndex) : OperationsBase(operationIndex) {
     mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
-bool Softmax::validate() {
-    const auto inputRank = getInputOperandDimensions(0).size();
-    if ( !isValidInputTensor(0) || inputRank > 4 ) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
-    }
-
-    ALOGV("%s PASSED", __func__);
-    return true;
-}
-
 std::shared_ptr<ngraph::Node> Softmax::createNode() {
     // Creating input nodes
     std::shared_ptr<ngraph::Node> input, outputNode;

--- a/ngraph_creator/operations/src/SpaceToBatch.cpp
+++ b/ngraph_creator/operations/src/SpaceToBatch.cpp
@@ -16,21 +16,17 @@ bool SpaceToBatch::validate() {
     const auto inputRank = getInputOperandDimensions(0).size();
 
     if (inputRank != 4) return false;
-    if ( !isValidInputTensor(0) || !isValidInputTensor(1) || !isValidInputTensor(2) ) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
+
+    auto& block_shape_OperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+    // TODO: Add Support for all_tensors_as_inputs
+    if (!sModelInfo->isOperandLifeTimeConst(block_shape_OperandIndex)) {
+        ALOGE("%s Only Constant dimensions supported now", __func__);
+        return false;
     }
 
-
-    auto& input_OperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
-    auto& block_shape_OperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
-    auto& pad_OperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 2);
-
-    //check operand lifetime is const or not as for now only const operand lifetime is supported
+    auto pad_OperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 2);
     // TODO: Add Support for all_tensors_as_inputs
-    if (!sModelInfo->isOperandLifeTimeConst(input_OperandIndex) ||
-        !sModelInfo->isOperandLifeTimeConst(block_shape_OperandIndex) ||
-        !sModelInfo->isOperandLifeTimeConst(pad_OperandIndex)) {
+    if (!sModelInfo->isOperandLifeTimeConst(pad_OperandIndex)) {
         ALOGE("%s Only Constant dimensions supported now", __func__);
         return false;
     }

--- a/ngraph_creator/operations/src/Squeeze.cpp
+++ b/ngraph_creator/operations/src/Squeeze.cpp
@@ -12,31 +12,16 @@ Squeeze::Squeeze(int operationIndex) : OperationsBase(operationIndex) {
 }
 
 bool Squeeze::validate() {
-    const auto inputRank = getInputOperandDimensions(0).size();
-    if (inputRank > 4) return false;
-
-    if ( !isValidInputTensor(0)) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
-    }
     // TODO: Add Support for all_tensors_as_inputs
-    const auto& dimsOperandIndex1 = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
+    const auto& dimsOperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
 
-    if (!sModelInfo->isOperandLifeTimeConst(dimsOperandIndex1)) {
+    // TODO: Support OmittedInput.
+    // The empty 2nd argument in Squeeze op causes dynamic output
+    // To add support, the dims will have to be calculated statically
+    if (sModelInfo->isOmittedInput(mNnapiOperationIndex, 1) ||
+        !sModelInfo->isOperandLifeTimeConst(dimsOperandIndex)) {
         ALOGE("%s Only Constant dimensions supported now", __func__);
         return false;
-    }
-    const auto& inputsSize = sModelInfo->getOperationInputsSize(mNnapiOperationIndex);
-    if (inputsSize == 2) {
-        const auto& dimsOperandIndex2 = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
-        // TODO: Support OmittedInput.
-        // The empty 2nd argument in Squeeze op causes dynamic output
-        // To add support, the dims will have to be calculated statically
-        if (!isValidInputTensor(1) || !sModelInfo->isOperandLifeTimeConst(dimsOperandIndex2) ||
-        sModelInfo->isOmittedInput(mNnapiOperationIndex, 1) ) {
-            ALOGE("%s Invalid operand type or operand lifetime", __func__);
-            return false;
-        }
     }
 
     return true;

--- a/ngraph_creator/operations/src/Sub.cpp
+++ b/ngraph_creator/operations/src/Sub.cpp
@@ -11,33 +11,6 @@ Sub::Sub(int operationIndex) : OperationsBase(operationIndex) {
     mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
-bool Sub::validate() {
-    auto operandIndex1 = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
-    auto operandIndex2 = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
-    const auto& elementType1 = sModelInfo->getOperandType(operandIndex1);
-    const auto& elementType2 = sModelInfo->getOperandType(operandIndex2);
-    if ( !isValidInputTensor(0) || !isValidInputTensor(1) ) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
-    }
-
-    // check if both tensors are of same type
-    if(elementType1 != elementType2 ) {
-        ALOGE("%s Input type mismatch", __func__);
-        return false;
-    } else if ( elementType1 == OperandType::TENSOR_INT32 ) {
-        //In 1.3 For a {@link OperandType::TENSOR_INT32} tensor,
-        //the {@link FusedActivationFunc} must be "NONE".
-        auto activationFn = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
-        if (activationFn != 0) {
-            ALOGE("%s Activation type must be none for TENSOR_INT32 type", __func__);
-            return false;
-        }
-    }
-    ALOGV("%s PASSED", __func__);
-    return true;
-}
-
 std::shared_ptr<ngraph::Node> Sub::createNode() {
     // Creating input nodes
     std::shared_ptr<ngraph::Node> input1, input2;

--- a/ngraph_creator/operations/src/Tanh.cpp
+++ b/ngraph_creator/operations/src/Tanh.cpp
@@ -11,17 +11,6 @@ Tanh::Tanh(int operationIndex) : OperationsBase(operationIndex) {
     mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
-bool Tanh::validate() {
-    const auto inputRank = getInputOperandDimensions(0).size();
-    if ( !isValidInputTensor(0) || inputRank > 4 ) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
-    }
-
-    ALOGV("%s PASSED", __func__);
-    return true;
-}
-
 std::shared_ptr<ngraph::Node> Tanh::createNode() {
     // Creating input nodes
     std::shared_ptr<ngraph::Node> input;

--- a/ngraph_creator/operations/src/Transpose.cpp
+++ b/ngraph_creator/operations/src/Transpose.cpp
@@ -13,23 +13,13 @@ Transpose::Transpose(int operationIndex) : OperationsBase(operationIndex) {
 
 bool Transpose::validate() {
     // TODO: Add Support for all_tensors_as_inputs
-    const auto& dimsOperandIndex1 = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
-    const auto inputRank = getInputOperandDimensions(0).size();
-    if ( !isValidInputTensor(0) || inputRank > 4) {
-         ALOGE("%s Empty  or Invalid dimensions size for input", __func__);
-         return false;
+    const auto& dimsOperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+    const auto& dims = getInputOperandDimensions(1);
+    if (!dims.empty() && dims[0] != 0 && !sModelInfo->isOperandLifeTimeConst(dimsOperandIndex)) {
+        ALOGE("%s Only Constant dimensions supported now", __func__);
+        return false;
     }
 
-    const auto& inputsSize = sModelInfo->getOperationInputsSize(mNnapiOperationIndex);
-    if (inputsSize == 2) {
-        const auto& dimsOperandIndex2 = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
-        if (!isValidInputTensor(1) || !sModelInfo->isOperandLifeTimeConst(dimsOperandIndex2)) {
-            ALOGE("%s Invalid operand type or operand lifetime", __func__);
-            return false;
-        }
-    }
-
-    ALOGV("%s PASSED", __func__);
     return true;
 }
 
@@ -40,12 +30,14 @@ std::shared_ptr<ngraph::Node> Transpose::createNode() {
     input = getInputNode(0);
 
     std::shared_ptr<ngraph::Node> order;
-    order = createConstNode(ngraph::element::i32, {0}, convertToVector(0));
 
-    const auto& inputsSize = sModelInfo->getOperationInputsSize(mNnapiOperationIndex);
-    if (inputsSize == 2) {
+    const auto& dims = getInputOperandDimensions(1);
+    if (!dims.empty() && dims[0] != 0) {
         order = getInputNode(1);
+    } else {
+        order = createConstNode(ngraph::element::i32, {0}, convertToVector(0));
     }
+
     std::shared_ptr<ngraph::Node> outputNode;
 
     outputNode = std::make_shared<ngraph::opset3::Transpose>(input, order);

--- a/ngraph_creator/operations/src/TransposeConv2D.cpp
+++ b/ngraph_creator/operations/src/TransposeConv2D.cpp
@@ -22,7 +22,7 @@ bool TransposeConv2D::validate() {
               inputDimensionsSize, filterDimensionsSize);
         return false;
     }
-    if (!isValidInputTensor(0) || !isValidInputTensor(1) || !isValidInputTensor(2)) {
+    if (!isValidInputTensor(0) || !isValidInputTensor(1)) {
         ALOGE("%s Invalid dimensions for input or filter", __func__);
         return false;
     }
@@ -38,16 +38,8 @@ bool TransposeConv2D::validate() {
     // TODO: Issue from OV 2021.4, remove this check once CVS-61723 is resolved
     // Workaround to ignore VTS large input error test cases
     const auto& inputDimensions = getInputOperandDimensions(0);
-    const auto& filterDimensions = getInputOperandDimensions(1);
-    const auto& biasDimensions = getInputOperandDimensions(2);
 
-    if (inputDimensions[1] == 1 && inputDimensions[2] == 1 && inputDimensions[3] == 1) {
-        return false;
-    }
-    //check if the bias dimension ==  filter depth_out && filter depth_in == input depth_in
-    if(filterDimensions[0] != biasDimensions[0] && biasDimensions[3] != inputDimensions[3]) {
-        return false;
-    }
+    if (inputDimensions[1] == 1 && inputDimensions[2] == 1 && inputDimensions[3] == 1) return false;
 
     ALOGV("%s PASSED", __func__);
     return true;

--- a/ngraph_creator/src/OperationsFactory.cpp
+++ b/ngraph_creator/src/OperationsFactory.cpp
@@ -26,8 +26,8 @@ std::shared_ptr<OperationsBase> OperationsFactory::getOperation(
             return std::make_shared<Argmax>(operationIndex);
         case OperationType::ARGMIN:
             return std::make_shared<Argmin>(operationIndex);
-        // case OperationType::AVERAGE_POOL_2D:
-        //     return std::make_shared<AveragePool2D>(operationIndex);
+        case OperationType::AVERAGE_POOL_2D:
+            return std::make_shared<AveragePool2D>(operationIndex);
         case OperationType::BATCH_TO_SPACE_ND:
             return std::make_shared<BatchToSpace>(operationIndex);
         case OperationType::BIDIRECTIONAL_SEQUENCE_RNN:
@@ -70,10 +70,10 @@ std::shared_ptr<OperationsBase> OperationsFactory::getOperation(
             return std::make_shared<GroupedConv2d>(operationIndex);
         case OperationType::INSTANCE_NORMALIZATION:
             return std::make_shared<InstanceNormalization>(operationIndex);
-        // case OperationType::L2_POOL_2D:
-        //     return std::make_shared<L2Pooling2D>(operationIndex);
-        // case OperationType::L2_NORMALIZATION:
-        //     return std::make_shared<L2Normalization>(operationIndex);
+        case OperationType::L2_POOL_2D:
+            return std::make_shared<L2Pooling2D>(operationIndex);
+        case OperationType::L2_NORMALIZATION:
+            return std::make_shared<L2Normalization>(operationIndex);
         case OperationType::LSTM:
             return std::make_shared<LSTM>(operationIndex);
         case OperationType::LESS:
@@ -144,10 +144,10 @@ std::shared_ptr<OperationsBase> OperationsFactory::getOperation(
             return std::make_shared<ROIPooling>(operationIndex);
         case OperationType::RSQRT:
             return std::make_shared<RSQRT>(operationIndex);
-        // case OperationType::RESIZE_BILINEAR:
-        //     return std::make_shared<ResizeBilinear>(operationIndex);
-        // case OperationType::RESIZE_NEAREST_NEIGHBOR:
-        //     return std::make_shared<ResizeNearestNeighbor>(operationIndex);
+        case OperationType::RESIZE_BILINEAR:
+            return std::make_shared<ResizeBilinear>(operationIndex);
+        case OperationType::RESIZE_NEAREST_NEIGHBOR:
+            return std::make_shared<ResizeNearestNeighbor>(operationIndex);
         case OperationType::SELECT:
             return std::make_shared<Select>(operationIndex);
         case OperationType::SOFTMAX:


### PR DESCRIPTION
Certain operations were disabled and limitations were applied to a few other operations as part of OAM-102888 : e19bead, 0722c03. These changes were needed due to the CTS failures observed on Android_S while using NNHAL1.3.

Here, we are re-enabling these operations since it is blocking many usecases like Image Classification, etc.

Tracked-On: OAM-105480
Signed-off-by: Anoob Anto K <anoob.anto.kodankandath@intel.com>