### PR TITLE
Remove temporary files after use

### DIFF
--- a/BasePreparedModel.h
+++ b/BasePreparedModel.h
@@ -55,6 +55,9 @@ class BasePreparedModel : public V1_3::IPreparedModel {
 public:
     BasePreparedModel(const IntelDeviceType device, const Model& model) : mTargetDevice(device) {
         mModelInfo = std::make_shared<NnapiModelInfo>(model);
+        mXmlFile = std::string("/data/vendor/neuralnetworks/") + std::to_string(mFileId) + std::string(".xml");
+        mBinFile = std::string("/data/vendor/neuralnetworks/") + std::to_string(mFileId) + std::string(".bin");
+        mFileId++;
     }
 
     virtual ~BasePreparedModel() { deinitialize(); }
@@ -86,7 +89,7 @@ public:
 
     virtual bool initialize();
     virtual bool checkRemoteConnection();
-    virtual bool loadRemoteModel();
+    virtual bool loadRemoteModel(const std::string& ir_xml, const std::string& ir_bin);
 
     std::shared_ptr<NnapiModelInfo> getModelInfo() { return mModelInfo; }
 
@@ -103,6 +106,10 @@ protected:
     std::shared_ptr<NnapiModelInfo> mModelInfo;
     std::shared_ptr<NgraphNetworkCreator> mNgraphNetCreator;
     std::shared_ptr<IIENetwork> mPlugin;
+private:
+    static uint32_t mFileId;
+    std::string mXmlFile;
+    std::string mBinFile;
 };
 
 class BaseFencedExecutionCallback : public V1_3::IFencedExecutionCallback {

--- a/DetectionClient.cpp
+++ b/DetectionClient.cpp
@@ -47,19 +47,19 @@ Status DetectionClient::sendFile(std::string fileName,
     return writer->Finish();
 }
 
-std::string DetectionClient::sendIRs(bool& flag) {
+std::string DetectionClient::sendIRs(bool& flag, const std::string& ir_xml, const std::string& ir_bin) {
     ReplyStatus reply;
     ClientContext context;
     std::unique_ptr<ClientWriter<RequestDataChunks> > writerXml =
         std::unique_ptr<ClientWriter<RequestDataChunks> >(stub_->sendXml(&context, &reply));
-    Status status = sendFile(IR_XML, writerXml);
+    Status status = sendFile(ir_xml, writerXml);
 
     if (status.ok()) {
         ClientContext newContext;
         std::unique_ptr<ClientWriter<RequestDataChunks> > writerBin =
             std::unique_ptr<ClientWriter<RequestDataChunks> >(
                 stub_->sendBin(&newContext, &reply));
-        status = sendFile(IR_BIN, writerBin);
+        status = sendFile(ir_bin, writerBin);
         if (status.ok()) {
             flag = reply.status();
             return (flag ? "status True" : "status False");

--- a/DetectionClient.h
+++ b/DetectionClient.h
@@ -22,9 +22,6 @@ using objectDetection::RequestDataTensors;
 using objectDetection::RequestString;
 using time_point = std::chrono::system_clock::time_point;
 
-static std::string IR_XML("/data/vendor/neuralnetworks/ngraph_ir.xml");
-static std::string IR_BIN("/data/vendor/neuralnetworks/ngraph_ir.bin");
-
 class DetectionClient {
 public:
     DetectionClient(std::shared_ptr<Channel> channel) : stub_(Detection::NewStub(channel)){}
@@ -34,7 +31,7 @@ public:
     Status sendFile(std::string fileName,
                     std::unique_ptr<ClientWriter<RequestDataChunks> >& writer);
 
-    std::string sendIRs(bool& flag);
+    std::string sendIRs(bool& flag, const std::string& ir_xml, const std::string& ir_bin);
 
     void add_input_data(std::string label, const uint8_t* buffer, std::vector<size_t> shape, uint32_t size);
     void get_output_data(std::string label, uint8_t* buffer, std::vector<size_t> shape);

--- a/IENetwork.cpp
+++ b/IENetwork.cpp
@@ -9,7 +9,7 @@
 
 namespace android::hardware::neuralnetworks::nnhal {
 
-bool IENetwork::loadNetwork() {
+bool IENetwork::loadNetwork(const std::string& ir_xml, const std::string& ir_bin) {
     ALOGV("%s", __func__);
 
 #if __ANDROID__
@@ -38,8 +38,7 @@ bool IENetwork::loadNetwork() {
         compiled_model = ie.compile_model(mNetwork, deviceStr);
         ALOGD("loadNetwork is done....");
 #if __ANDROID__
-        ov::serialize(mNetwork, "/data/vendor/neuralnetworks/ngraph_ir.xml",
-                        "/data/vendor/neuralnetworks/ngraph_ir.bin",
+        ov::serialize(mNetwork, ir_xml, ir_bin,
                         ov::pass::Serialize::Version::IR_V11);
 #else
         ov::pass::Manager manager;
@@ -48,7 +47,7 @@ bool IENetwork::loadNetwork() {
 #endif
         std::vector<ov::Output<ov::Node>> modelInput = mNetwork->inputs();
         mInferRequest = compiled_model.create_infer_request();
-        ALOGD("CreateInfereRequest is done....");
+        ALOGD("CreateInferRequest is done....");
 
     } else {
         ALOGE("Invalid Network pointer");
@@ -73,10 +72,9 @@ ov::Tensor IENetwork::getOutputTensor(const std::size_t index) {
 }
 
 void IENetwork::infer() {
-    ALOGI("infer Network\n");
-    mInferRequest.start_async();
-    mInferRequest.wait_for(std::chrono::milliseconds(10000));
-    ALOGI("infer request completed");
+    ALOGI("infer requested");
+    mInferRequest.infer();
+    ALOGI("infer completed");
 }
 
 }  // namespace android::hardware::neuralnetworks::nnhal

--- a/IENetwork.h
+++ b/IENetwork.h
@@ -21,7 +21,7 @@ namespace android::hardware::neuralnetworks::nnhal {
 class IIENetwork {
 public:
     virtual ~IIENetwork() = default;
-    virtual bool loadNetwork() = 0;
+    virtual bool loadNetwork(const std::string& ir_xml, const std::string& ir_bin) = 0;
     virtual ov::InferRequest getInferRequest() = 0;
     virtual void infer() = 0;
     virtual void queryState() = 0;
@@ -42,7 +42,7 @@ public:
     IENetwork(IntelDeviceType device, std::shared_ptr<ov::Model> network)
         : mTargetDevice(device), mNetwork(network) {}
 
-    virtual bool loadNetwork();
+    virtual bool loadNetwork(const std::string& ir_xml, const std::string& ir_bin);
     ov::Tensor getTensor(const std::string& outName);
     ov::Tensor getInputTensor(const std::size_t index);
     ov::Tensor getOutputTensor(const std::size_t index);


### PR DESCRIPTION
Deleting the serialized IR files generated by NNHAL, at the end of its usage.

Tracked-On: OAM-106941