### PR TITLE
Ai benchmark improvements

### DIFF
--- a/BasePreparedModel.cpp
+++ b/BasePreparedModel.cpp
@@ -414,7 +414,7 @@ void asyncExecute(const Request& request, MeasureTiming measure, BasePreparedMod
 }
 
 static std::tuple<ErrorStatus, hidl_vec<V1_2::OutputShape>, Timing> executeSynchronouslyBase(
-    const Request& request, MeasureTiming measure, BasePreparedModel* preparedModel,
+    const V1_3::Request& request, MeasureTiming measure, BasePreparedModel* preparedModel,
     time_point driverStart) {
     ALOGV("Entering %s", __func__);
     auto modelInfo = preparedModel->getModelInfo();
@@ -423,7 +423,7 @@ static std::tuple<ErrorStatus, hidl_vec<V1_2::OutputShape>, Timing> executeSynch
     time_point driverEnd, deviceStart, deviceEnd;
     std::vector<RunTimePoolInfo> requestPoolInfos;
     auto errorStatus = modelInfo->setRunTimePoolInfosFromHidlMemories(request.pools);
-    if (errorStatus != ErrorStatus::NONE) {
+    if (errorStatus != V1_3::ErrorStatus::NONE) {
         ALOGE("Failed to set runtime pool info from HIDL memories");
         return {ErrorStatus::GENERAL_FAILURE, {}, kNoTiming};
     }
@@ -647,7 +647,7 @@ Return<void> BasePreparedModel::executeSynchronously(const Request& request, Mea
         return Void();
     }
     auto [status, outputShapes, timing] =
-        executeSynchronouslyBase(request, measure, this, driverStart);
+        executeSynchronouslyBase(convertToV1_3(request), measure, this, driverStart);
     cb(status, std::move(outputShapes), timing);
     ALOGV("Exiting %s", __func__);
     return Void();
@@ -662,12 +662,12 @@ Return<void> BasePreparedModel::executeSynchronously_1_3(const V1_3::Request& re
     time_point driverStart;
     if (measure == MeasureTiming::YES) driverStart = now();
 
-    if (!validateRequest(convertToV1_0(request), convertToV1_2(mModelInfo->getModel()))) {
+    if (!validateRequest(request, mModelInfo->getModel())) {
         cb(V1_3::ErrorStatus::INVALID_ARGUMENT, {}, kNoTiming);
         return Void();
     }
     auto [status, outputShapes, timing] =
-        executeSynchronouslyBase(convertToV1_0(request), measure, this, driverStart);
+        executeSynchronouslyBase(request, measure, this, driverStart);
     cb(convertToV1_3(status), std::move(outputShapes), timing);
     ALOGV("Exiting %s", __func__);
     return Void();

--- a/BasePreparedModel.cpp
+++ b/BasePreparedModel.cpp
@@ -79,7 +79,7 @@ bool BasePreparedModel::initialize() {
     }
     try {
         mPlugin = std::make_shared<IENetwork>(mTargetDevice);
-        mPlugin->loadNetwork(ov_model, mXmlFile, mBinFile);
+        mPlugin->createNetwork(ov_model, mXmlFile, mBinFile);
     } catch (const std::exception& ex) {
         ALOGE("%s Exception !!! %s", __func__, ex.what());
         return false;
@@ -105,7 +105,14 @@ bool BasePreparedModel::initialize() {
         if (disableOffload) break;
     }
     if (!disableOffload) {
+        ALOGD("%s GRPC load model on remote",__func__);
         loadRemoteModel(mXmlFile, mBinFile);
+    }
+
+    if (disableOffload || !(mRemoteCheck)) {
+        ALOGI("%s load model on native for inference",__func__);
+        mPlugin->loadNetwork(mXmlFile);
+        setRemoteEnabled(false);
     }
 
     size_t tensorIndex = 0;
@@ -488,9 +495,27 @@ static std::tuple<ErrorStatus, hidl_vec<V1_2::OutputShape>, Timing> executeSynch
         if(preparedModel->mRemoteCheck && preparedModel->mDetectionClient) {
             auto inOperandType = modelInfo->getOperandType(inIndex);
             preparedModel->mDetectionClient->add_input_data(std::to_string(tensorIndex), (uint8_t*)srcPtr, modelInfo->getOperand(inIndex).dimensions, len, inOperandType);
-        } else {
+            ALOGI("%s GRPC Remote Infer", __func__);
+            if (measure == MeasureTiming::YES) deviceStart = now();
+            ALOGV("%s Run", __func__);
+            auto reply = preparedModel->mDetectionClient->remote_infer();
+            if (measure == MeasureTiming::YES) deviceEnd = now();
+            ALOGI("***********GRPC server response************* %s", reply.c_str());
+            if (reply != "Success") {
+                bool is_success = false;
+                ALOGE("%s GRPC Remote infer failed, Switching to native infer", __func__);
+                preparedModel->setRemoteEnabled(false);
+                preparedModel->mDetectionClient->release(is_success);
+            }
+        }
+
+        if (!preparedModel->mRemoteCheck || !preparedModel->mDetectionClient->get_status()) {
             ov::Tensor destTensor;
             try {
+                if(!plugin->queryState()) {
+                    ALOGI("native model not loaded, starting model load");
+                    plugin->loadNetwork(preparedModel->mXmlFile);
+                }
                 destTensor = plugin->getInputTensor(tensorIndex);
             } catch (const std::exception& ex) {
                 ALOGE("%s Exception !!! %s", __func__, ex.what());
@@ -545,32 +570,17 @@ static std::tuple<ErrorStatus, hidl_vec<V1_2::OutputShape>, Timing> executeSynch
                     std::memcpy((uint8_t*)dest, (uint8_t*)srcPtr, len);
                     break;
             }
-        }
-
-    }
-
-    ALOGV("%s Run", __func__);
-
-    if (measure == MeasureTiming::YES) deviceStart = now();
-    if(preparedModel->mRemoteCheck) {
-        ALOGI("%s GRPC Remote Infer", __func__);
-        auto reply = preparedModel->mDetectionClient->remote_infer();
-        ALOGI("***********GRPC server response************* %s", reply.c_str());
-    }
-    if (!preparedModel->mRemoteCheck || !preparedModel->mDetectionClient->get_status()){
-        //Disable remote inference if a request fails
-        if(preparedModel->mRemoteCheck) {
-            preparedModel->setRemoteEnabled(false);
-        }
-        try {
-            ALOGV("%s Client Infer", __func__);
-            plugin->infer();
-        } catch (const std::exception& ex) {
-            ALOGE("%s Exception !!! %s", __func__, ex.what());
-            return {ErrorStatus::GENERAL_FAILURE, {}, kNoTiming};
+            if (measure == MeasureTiming::YES) deviceStart = now();
+            try {
+                ALOGV("%s RUN native infer", __func__);
+                plugin->infer();
+            } catch (const std::exception& ex) {
+                ALOGE("%s Exception !!! %s", __func__, ex.what());
+                return {ErrorStatus::GENERAL_FAILURE, {}, kNoTiming};
+            }
+            if (measure == MeasureTiming::YES) deviceEnd = now();
         }
     }
-    if (measure == MeasureTiming::YES) deviceEnd = now();
 
     for (size_t i = 0; i < request.outputs.size(); i++) {
         auto outIndex = modelInfo->getModelOutputIndex(i);
@@ -580,44 +590,45 @@ static std::tuple<ErrorStatus, hidl_vec<V1_2::OutputShape>, Timing> executeSynch
             continue;
         }
         ov::Tensor srcTensor;
-        try {
-            srcTensor = plugin->getOutputTensor(tensorIndex);
-        } catch (const std::exception& ex) {
-            ALOGE("%s Exception !!! %s", __func__, ex.what());
-            return {ErrorStatus::GENERAL_FAILURE, {}, kNoTiming};
-        }
-        auto operandType = modelInfo->getOperandType(outIndex);
-        uint32_t actualLength = srcTensor.get_byte_size();
         uint32_t expectedLength = 0;
         void* destPtr = modelInfo->getBlobFromMemoryPoolOut(request, i, expectedLength);
-        auto outputBlobDims = srcTensor.get_shape();
-
-        bool outputSizeMismatch = false;
-        if (actualLength != expectedLength) {
-            ALOGE("%s Invalid length at outIndex(%d) Actual:%d Expected:%d", __func__, outIndex,
-                  actualLength, expectedLength);
-            outputSizeMismatch = true;
-        }
-
-        // TODO: bug identified with OV2021.4 where for Pad operation, if the output dimensions is 1
-        // output dimension is coming as 0
-        if ((outputBlobDims.size() == 0) && (actualLength != 0)) {
-            std::vector<size_t> rdims = {1};
-            modelInfo->updateOutputshapes(i, rdims, outputSizeMismatch ? false : true);
-        } else
-            modelInfo->updateOutputshapes(i, outputBlobDims, outputSizeMismatch ? false : true);
-
-        if (outputSizeMismatch) {
-            ALOGE(
-                "Mismatch in actual and exepcted output sizes. Return with "
-                "OUTPUT_INSUFFICIENT_SIZE error");
-            return {ErrorStatus::OUTPUT_INSUFFICIENT_SIZE, modelInfo->getOutputShapes(), kNoTiming};
-        }
-        //copy output from remote infer
-        //TODO: Add support for other OperandType
         if (preparedModel->mRemoteCheck && preparedModel->mDetectionClient && preparedModel->mDetectionClient->get_status()) {
             preparedModel->mDetectionClient->get_output_data(std::to_string(i), (uint8_t*)destPtr, expectedLength);
         } else {
+            try {
+                srcTensor = plugin->getOutputTensor(tensorIndex);
+            } catch (const std::exception& ex) {
+                ALOGE("%s Exception !!! %s", __func__, ex.what());
+                return {ErrorStatus::GENERAL_FAILURE, {}, kNoTiming};
+            }
+            auto operandType = modelInfo->getOperandType(outIndex);
+            uint32_t actualLength = srcTensor.get_byte_size();
+            
+            auto outputBlobDims = srcTensor.get_shape();
+
+            bool outputSizeMismatch = false;
+            if (actualLength != expectedLength) {
+                ALOGE("%s Invalid length at outIndex(%d) Actual:%d Expected:%d", __func__, outIndex,
+                    actualLength, expectedLength);
+                outputSizeMismatch = true;
+            }
+
+            // TODO: bug identified with OV2021.4 where for Pad operation, if the output dimensions is 1
+            // output dimension is coming as 0
+            if ((outputBlobDims.size() == 0) && (actualLength != 0)) {
+                std::vector<size_t> rdims = {1};
+                modelInfo->updateOutputshapes(i, rdims, outputSizeMismatch ? false : true);
+            } else
+                modelInfo->updateOutputshapes(i, outputBlobDims, outputSizeMismatch ? false : true);
+
+            if (outputSizeMismatch) {
+                ALOGE(
+                    "Mismatch in actual and exepcted output sizes. Return with "
+                    "OUTPUT_INSUFFICIENT_SIZE error");
+                return {ErrorStatus::OUTPUT_INSUFFICIENT_SIZE, modelInfo->getOutputShapes(), kNoTiming};
+            }
+            //copy output from remote infer
+            //TODO: Add support for other OperandType
             switch (operandType) {
                 case OperandType::TENSOR_INT32:
                     std::memcpy((uint8_t*)destPtr, (uint8_t*)srcTensor.data<int32_t>(),

--- a/BasePreparedModel.h
+++ b/BasePreparedModel.h
@@ -49,10 +49,11 @@ namespace android::hardware::neuralnetworks::nnhal {
 template <class T>
 using vec = std::vector<T>;
 typedef uint8_t* memory;
-extern bool mRemoteCheck;
+
 extern std::shared_ptr<DetectionClient> mDetectionClient;
 class BasePreparedModel : public V1_3::IPreparedModel {
 public:
+    bool mRemoteCheck = false;
     BasePreparedModel(const IntelDeviceType device, const Model& model) : mTargetDevice(device) {
         mModelInfo = std::make_shared<NnapiModelInfo>(model);
         mXmlFile = std::string("/data/vendor/neuralnetworks/") + std::to_string(mFileId) + std::string(".xml");
@@ -90,6 +91,7 @@ public:
     virtual bool initialize();
     virtual bool checkRemoteConnection();
     virtual bool loadRemoteModel(const std::string& ir_xml, const std::string& ir_bin);
+    virtual void setRemoteEnabled(bool flag);
 
     std::shared_ptr<NnapiModelInfo> getModelInfo() { return mModelInfo; }
 

--- a/BasePreparedModel.h
+++ b/BasePreparedModel.h
@@ -53,6 +53,8 @@ typedef uint8_t* memory;
 class BasePreparedModel : public V1_3::IPreparedModel {
 public:
     bool mRemoteCheck = false;
+    std::string mXmlFile;
+    std::string mBinFile;
     BasePreparedModel(const IntelDeviceType device, const Model& model) : mTargetDevice(device) {
         mModelInfo = std::make_shared<NnapiModelInfo>(model);
         mXmlFile = MODEL_DIR + std::to_string(mFileId) + std::string(".xml");
@@ -110,8 +112,6 @@ protected:
     std::shared_ptr<IIENetwork> mPlugin;
 private:
     static uint32_t mFileId;
-    std::string mXmlFile;
-    std::string mBinFile;
     std::unordered_map<size_t, size_t> mInputsToTensorMap;
     std::unordered_map<size_t, size_t> mOutputsToTensorMap;
 };

--- a/BasePreparedModel.h
+++ b/BasePreparedModel.h
@@ -50,14 +50,13 @@ template <class T>
 using vec = std::vector<T>;
 typedef uint8_t* memory;
 
-extern std::shared_ptr<DetectionClient> mDetectionClient;
 class BasePreparedModel : public V1_3::IPreparedModel {
 public:
     bool mRemoteCheck = false;
     BasePreparedModel(const IntelDeviceType device, const Model& model) : mTargetDevice(device) {
         mModelInfo = std::make_shared<NnapiModelInfo>(model);
-        mXmlFile = std::string("/data/vendor/neuralnetworks/") + std::to_string(mFileId) + std::string(".xml");
-        mBinFile = std::string("/data/vendor/neuralnetworks/") + std::to_string(mFileId) + std::string(".bin");
+        mXmlFile = MODEL_DIR + std::to_string(mFileId) + std::string(".xml");
+        mBinFile = MODEL_DIR + std::to_string(mFileId) + std::string(".bin");
         mFileId++;
     }
 
@@ -90,7 +89,7 @@ public:
 
     virtual bool initialize();
     virtual bool checkRemoteConnection();
-    virtual bool loadRemoteModel(const std::string& ir_xml, const std::string& ir_bin);
+    virtual void loadRemoteModel(const std::string& ir_xml, const std::string& ir_bin);
     virtual void setRemoteEnabled(bool flag);
 
     std::shared_ptr<NnapiModelInfo> getModelInfo() { return mModelInfo; }
@@ -100,6 +99,7 @@ public:
     std::shared_ptr<IIENetwork> getPlugin() { return mPlugin; }
 
     std::shared_ptr<ov::Model> modelPtr;
+    std::shared_ptr<DetectionClient> mDetectionClient;
 
 protected:
     virtual void deinitialize();

--- a/BasePreparedModel.h
+++ b/BasePreparedModel.h
@@ -94,7 +94,8 @@ public:
 
     std::shared_ptr<NnapiModelInfo> getModelInfo() { return mModelInfo; }
 
-    std::shared_ptr<NgraphNetworkCreator> getNgraphNwCreator() { return mNgraphNetCreator; }
+    size_t getInputTensorIndex(size_t input);
+    size_t getOutputTensorIndex(size_t output);
 
     std::shared_ptr<IIENetwork> getPlugin() { return mPlugin; }
 
@@ -106,12 +107,13 @@ protected:
 
     IntelDeviceType mTargetDevice;
     std::shared_ptr<NnapiModelInfo> mModelInfo;
-    std::shared_ptr<NgraphNetworkCreator> mNgraphNetCreator;
     std::shared_ptr<IIENetwork> mPlugin;
 private:
     static uint32_t mFileId;
     std::string mXmlFile;
     std::string mBinFile;
+    std::unordered_map<size_t, size_t> mInputsToTensorMap;
+    std::unordered_map<size_t, size_t> mOutputsToTensorMap;
 };
 
 class BaseFencedExecutionCallback : public V1_3::IFencedExecutionCallback {

--- a/DetectionClient.cpp
+++ b/DetectionClient.cpp
@@ -37,7 +37,7 @@ Status DetectionClient::sendFile(std::string fileName,
         // ALOGI("GRPC sendFile read %d", s);
         request.set_data(buffer.data(), s);
         if (!writer->Write(request)) {
-            ALOGE("GRPC Broken Stream ");
+            ALOGE("GRPC broken stream ");
             break;
         }
     }
@@ -45,6 +45,22 @@ Status DetectionClient::sendFile(std::string fileName,
     writer->WritesDone();
     ALOGI("GRPC sendFile completed");
     return writer->Finish();
+}
+
+bool DetectionClient::isModelLoaded(std::string fileName) {
+    ReplyStatus reply;
+    ClientContext context;
+    RequestString request;
+    request.set_value(fileName);
+    time_point deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(20000);
+    context.set_deadline(deadline);
+    status = stub_->loadModel(&context, request, &reply);
+    if(status.ok()) {
+        return reply.status();
+    } else {
+        ALOGE("Model load failure: %s", status.error_message().c_str());
+    }
+    return false;
 }
 
 std::string DetectionClient::sendIRs(bool& flag, const std::string& ir_xml, const std::string& ir_bin) {
@@ -62,25 +78,75 @@ std::string DetectionClient::sendIRs(bool& flag, const std::string& ir_xml, cons
         status = sendFile(ir_bin, writerBin);
         if (status.ok()) {
             flag = reply.status();
-            return (flag ? "status True" : "status False");
+            //if model is sent succesfully trigger model loading
+            if (flag && isModelLoaded(ir_xml) ) {
+                flag = true;
+                return ("status True");
+            } else {
+                flag = false;
+                ALOGE("Model loading failed!!!");
+                return ("status False");
+            }
+        } else {
+            return ("status False");
         }
     }
     return std::string(status.error_message());
 }
 
-void DetectionClient::add_input_data(std::string label, const uint8_t* buffer, std::vector<size_t> shape, uint32_t size) {
+void DetectionClient::add_input_data(std::string label, const uint8_t* buffer, std::vector<size_t> shape, uint32_t size, android::hardware::neuralnetworks::nnhal::OperandType operandType) {
     const float* src;
     size_t index;
 
     DataTensor* input = request.add_data_tensors();
     input->set_node_name(label);
+    switch(operandType) {
+        case android::hardware::neuralnetworks::nnhal::OperandType::TENSOR_INT32: {
+            input->set_data_type(DataTensor::i32);
+            break;
+        }
+        case android::hardware::neuralnetworks::nnhal::OperandType::TENSOR_FLOAT16: {
+            input->set_data_type(DataTensor::f16);
+            break;
+        }
+        case android::hardware::neuralnetworks::nnhal::OperandType::TENSOR_FLOAT32: {
+            input->set_data_type(DataTensor::f32);
+            break;
+        }
+        case android::hardware::neuralnetworks::nnhal::OperandType::TENSOR_BOOL8: {
+            input->set_data_type(DataTensor::boolean);
+            break;
+        }
+        case android::hardware::neuralnetworks::nnhal::OperandType::TENSOR_QUANT8_ASYMM: {
+            input->set_data_type(DataTensor::u8);
+            break;
+        }
+        case android::hardware::neuralnetworks::nnhal::OperandType::TENSOR_QUANT8_SYMM:
+        case android::hardware::neuralnetworks::nnhal::OperandType::TENSOR_QUANT8_SYMM_PER_CHANNEL:
+        case android::hardware::neuralnetworks::nnhal::OperandType::TENSOR_QUANT8_ASYMM_SIGNED: {
+            input->set_data_type(DataTensor::i8);
+            break;
+        }
+        case android::hardware::neuralnetworks::nnhal::OperandType::TENSOR_QUANT16_SYMM: {
+            input->set_data_type(DataTensor::i16);
+            break;
+        }
+        case android::hardware::neuralnetworks::nnhal::OperandType::TENSOR_QUANT16_ASYMM: {
+            input->set_data_type(DataTensor::u16);
+            break;
+        }
+        default: {
+            input->set_data_type(DataTensor::u8);
+            break;
+        }
+    }
     for (index = 0; index < shape.size(); index++) {
         input->add_tensor_shape(shape[index]);
     }
     input->set_data(buffer, size);
 }
 
-void DetectionClient::get_output_data(std::string label, uint8_t* buffer, std::vector<size_t> shape) {
+void DetectionClient::get_output_data(std::string label, uint8_t* buffer, std::vector<size_t> shape, uint32_t expectedLength) {
     std::string src;
     size_t index;
     size_t size = 1;
@@ -91,6 +157,9 @@ void DetectionClient::get_output_data(std::string label, uint8_t* buffer, std::v
     for (index = 0; index < reply.data_tensors_size(); index++) {
         if (label.compare(reply.data_tensors(index).node_name()) == 0) {
             src = reply.data_tensors(index).data();
+            if(expectedLength != src.length()) {
+                ALOGE("Length mismatch error: expected length %d , actual length %d", expectedLength, src.length());
+            }
             memcpy(buffer, src.data(), src.length());
             break;
         }
@@ -104,7 +173,7 @@ void DetectionClient::clear_data() {
 
 std::string DetectionClient::remote_infer() {
     ClientContext context;
-    time_point deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(20000);
+    time_point deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(10000);
     context.set_deadline(deadline);
 
     status = stub_->getInferResult(&context, request, &reply);

--- a/DetectionClient.cpp
+++ b/DetectionClient.cpp
@@ -192,7 +192,10 @@ std::string DetectionClient::remote_infer() {
     request.mutable_token()->set_data(mToken);
     status = stub_->getInferResult(&context, request, &reply);
     if (status.ok()) {
-        if (reply.data_tensors_size() == 0) ALOGE("GRPC reply empty, ovms failure ?");
+        if (reply.data_tensors_size() == 0) {
+            ALOGE("GRPC reply empty, ovms failure ?");
+            return "Failure";
+        }
         return "Success";
     } else {
         ALOGE("GRPC Error code: %d, message: %s", status.error_code(),

--- a/DetectionClient.cpp
+++ b/DetectionClient.cpp
@@ -111,7 +111,7 @@ std::string DetectionClient::sendIRs(bool& flag, const std::string& ir_xml, cons
     return std::string(status.error_message());
 }
 
-void DetectionClient::add_input_data(std::string label, const uint8_t* buffer, std::vector<size_t> shape, uint32_t size, android::hardware::neuralnetworks::nnhal::OperandType operandType) {
+void DetectionClient::add_input_data(std::string label, const uint8_t* buffer, std::vector<uint32_t> shape, uint32_t size, android::hardware::neuralnetworks::nnhal::OperandType operandType) {
     const float* src;
     size_t index;
 
@@ -163,14 +163,10 @@ void DetectionClient::add_input_data(std::string label, const uint8_t* buffer, s
     input->set_data(buffer, size);
 }
 
-void DetectionClient::get_output_data(std::string label, uint8_t* buffer, std::vector<size_t> shape, uint32_t expectedLength) {
+void DetectionClient::get_output_data(std::string label, uint8_t* buffer, uint32_t expectedLength) {
     std::string src;
     size_t index;
-    size_t size = 1;
 
-    for (index = 0; index < shape.size(); index++) {
-        size *= shape[index];
-    }
     for (index = 0; index < reply.data_tensors_size(); index++) {
         if (label.compare(reply.data_tensors(index).node_name()) == 0) {
             src = reply.data_tensors(index).data();

--- a/DetectionClient.cpp
+++ b/DetectionClient.cpp
@@ -8,7 +8,7 @@ std::string DetectionClient::prepare(bool& flag) {
     request.set_value("");
     ReplyStatus reply;
     ClientContext context;
-    time_point deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(100);
+    time_point deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(10000);
     context.set_deadline(deadline);
 
     Status status = stub_->prepare(&context, request, &reply);
@@ -24,7 +24,7 @@ std::string DetectionClient::prepare(bool& flag) {
 Status DetectionClient::sendFile(std::string fileName,
                 std::unique_ptr<ClientWriter<RequestDataChunks> >& writer) {
     RequestDataChunks request;
-    uint32_t CHUNK_SIZE = 1024 * 1024;
+    uint32_t CHUNK_SIZE = 10 * 1024 * 1024;
     std::ifstream fin(fileName, std::ifstream::binary);
     std::vector<char> buffer(CHUNK_SIZE, 0);
     ALOGV("GRPC sendFile %s", fileName.c_str());
@@ -52,7 +52,7 @@ bool DetectionClient::isModelLoaded(std::string fileName) {
     ClientContext context;
     RequestString request;
     request.set_value(fileName);
-    time_point deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(20000);
+    time_point deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(300000);
     context.set_deadline(deadline);
     status = stub_->loadModel(&context, request, &reply);
     if(status.ok()) {

--- a/DetectionClient.cpp
+++ b/DetectionClient.cpp
@@ -5,7 +5,7 @@
 
 std::string DetectionClient::prepare(bool& flag) {
     RequestString request;
-    request.set_value("");
+    request.mutable_token()->set_data(mToken);
     ReplyStatus reply;
     ClientContext context;
     time_point deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(10000);
@@ -21,9 +21,26 @@ std::string DetectionClient::prepare(bool& flag) {
     }
 }
 
+std::string DetectionClient::release(bool& flag) {
+    RequestString request;
+    request.mutable_token()->set_data(mToken);
+    ReplyStatus reply;
+    ClientContext context;
+
+    Status status = stub_->release(&context, request, &reply);
+
+    if (status.ok()) {
+        flag = reply.status();
+        return (flag ? "status True" : "status False");
+    } else {
+        return std::string(status.error_message());
+    }
+}
+
 Status DetectionClient::sendFile(std::string fileName,
                 std::unique_ptr<ClientWriter<RequestDataChunks> >& writer) {
     RequestDataChunks request;
+    request.mutable_token()->set_data(mToken);
     uint32_t CHUNK_SIZE = 10 * 1024 * 1024;
     std::ifstream fin(fileName, std::ifstream::binary);
     std::vector<char> buffer(CHUNK_SIZE, 0);
@@ -51,7 +68,7 @@ bool DetectionClient::isModelLoaded(std::string fileName) {
     ReplyStatus reply;
     ClientContext context;
     RequestString request;
-    request.set_value(fileName);
+    request.mutable_token()->set_data(mToken);
     time_point deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(300000);
     context.set_deadline(deadline);
     status = stub_->loadModel(&context, request, &reply);
@@ -176,6 +193,7 @@ std::string DetectionClient::remote_infer() {
     time_point deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(10000);
     context.set_deadline(deadline);
 
+    request.mutable_token()->set_data(mToken);
     status = stub_->getInferResult(&context, request, &reply);
     if (status.ok()) {
         if (reply.data_tensors_size() == 0) ALOGE("GRPC reply empty, ovms failure ?");

--- a/DetectionClient.h
+++ b/DetectionClient.h
@@ -7,6 +7,7 @@
 #include <android/log.h>
 #include <log/log.h>
 #include <android-base/logging.h>
+#include "Driver.h"
 #include "nnhal_object_detection.grpc.pb.h"
 
 using grpc::Channel;
@@ -33,8 +34,9 @@ public:
 
     std::string sendIRs(bool& flag, const std::string& ir_xml, const std::string& ir_bin);
 
-    void add_input_data(std::string label, const uint8_t* buffer, std::vector<size_t> shape, uint32_t size);
-    void get_output_data(std::string label, uint8_t* buffer, std::vector<size_t> shape);
+    bool isModelLoaded(std::string fileName);
+    void add_input_data(std::string label, const uint8_t* buffer, std::vector<size_t> shape, uint32_t size, android::hardware::neuralnetworks::nnhal::OperandType operandType);
+    void get_output_data(std::string label, uint8_t* buffer, std::vector<size_t> shape, uint32_t expectedLength);
     void clear_data();
     std::string remote_infer();
     bool get_status();

--- a/DetectionClient.h
+++ b/DetectionClient.h
@@ -23,11 +23,14 @@ using objectDetection::RequestDataTensors;
 using objectDetection::RequestString;
 using time_point = std::chrono::system_clock::time_point;
 
+#define MODEL_DIR std::string("/data/vendor/neuralnetworks/")
+
 class DetectionClient {
 public:
-    DetectionClient(std::shared_ptr<Channel> channel) : stub_(Detection::NewStub(channel)){}
+    DetectionClient(std::shared_ptr<Channel> channel, uint32_t token) : stub_(Detection::NewStub(channel)), mToken(token) {}
 
     std::string prepare(bool& flag);
+    std::string release(bool& flag);
 
     Status sendFile(std::string fileName,
                     std::unique_ptr<ClientWriter<RequestDataChunks> >& writer);
@@ -46,6 +49,7 @@ private:
     RequestDataTensors request;
     ReplyDataTensors reply;
     Status status;
+    uint32_t mToken;
 };
 
 #endif

--- a/DetectionClient.h
+++ b/DetectionClient.h
@@ -38,8 +38,8 @@ public:
     std::string sendIRs(bool& flag, const std::string& ir_xml, const std::string& ir_bin);
 
     bool isModelLoaded(std::string fileName);
-    void add_input_data(std::string label, const uint8_t* buffer, std::vector<size_t> shape, uint32_t size, android::hardware::neuralnetworks::nnhal::OperandType operandType);
-    void get_output_data(std::string label, uint8_t* buffer, std::vector<size_t> shape, uint32_t expectedLength);
+    void add_input_data(std::string label, const uint8_t* buffer, std::vector<uint32_t> shape, uint32_t size, android::hardware::neuralnetworks::nnhal::OperandType operandType);
+    void get_output_data(std::string label, uint8_t* buffer, uint32_t expectedLength);
     void clear_data();
     std::string remote_infer();
     bool get_status();

--- a/Driver.cpp
+++ b/Driver.cpp
@@ -245,8 +245,8 @@ Return<void> Driver::getSupportedOperations_1_2(const V1_2_Model& model,
     }
 
     auto modelInfo = std::make_shared<NnapiModelInfo>(convertToV1_3(model));
-    NgraphNetworkCreator ngraphCreatorInst(modelInfo, mDeviceType);
-    ngraphCreatorInst.getSupportedOperations(supported);
+    std::shared_ptr<NgraphNetworkCreator> ngraphCreatorInst = std::make_shared<NgraphNetworkCreator>(modelInfo, mDeviceType);
+    ngraphCreatorInst->getSupportedOperations(supported);
 
     cb(ErrorStatus::NONE, supported);
     ALOGV("Exiting %s", __func__);
@@ -373,8 +373,8 @@ Return<void> Driver::getSupportedOperations_1_3(const Model& model,
     }
 
     auto modelInfo = std::make_shared<NnapiModelInfo>(model);
-    NgraphNetworkCreator ngraphCreatorInst(modelInfo, mDeviceType);
-    ngraphCreatorInst.getSupportedOperations(supported);
+    std::shared_ptr<NgraphNetworkCreator> ngraphCreatorInst = std::make_shared<NgraphNetworkCreator>(modelInfo, mDeviceType);
+    ngraphCreatorInst->getSupportedOperations(supported);
 
     cb(V1_3::ErrorStatus::NONE, supported);
     ALOGV("Exiting %s", __func__);

--- a/IENetwork.h
+++ b/IENetwork.h
@@ -21,7 +21,7 @@ namespace android::hardware::neuralnetworks::nnhal {
 class IIENetwork {
 public:
     virtual ~IIENetwork() = default;
-    virtual bool loadNetwork(const std::string& ir_xml, const std::string& ir_bin) = 0;
+    virtual bool loadNetwork(std::shared_ptr<ov::Model> network, const std::string& ir_xml, const std::string& ir_bin) = 0;
     virtual ov::InferRequest getInferRequest() = 0;
     virtual void infer() = 0;
     virtual void queryState() = 0;
@@ -34,15 +34,13 @@ public:
 class IENetwork : public IIENetwork {
 private:
     IntelDeviceType mTargetDevice;
-    std::shared_ptr<ov::Model> mNetwork;
-    ov::CompiledModel compiled_model;
     ov::InferRequest mInferRequest;
 
 public:
-    IENetwork(IntelDeviceType device, std::shared_ptr<ov::Model> network)
-        : mTargetDevice(device), mNetwork(network) {}
+    IENetwork(IntelDeviceType device)
+        : mTargetDevice(device) {}
 
-    virtual bool loadNetwork(const std::string& ir_xml, const std::string& ir_bin);
+    virtual bool loadNetwork(std::shared_ptr<ov::Model> network, const std::string& ir_xml, const std::string& ir_bin);
     ov::Tensor getTensor(const std::string& outName);
     ov::Tensor getInputTensor(const std::size_t index);
     ov::Tensor getOutputTensor(const std::size_t index);

--- a/IENetwork.h
+++ b/IENetwork.h
@@ -21,10 +21,11 @@ namespace android::hardware::neuralnetworks::nnhal {
 class IIENetwork {
 public:
     virtual ~IIENetwork() = default;
-    virtual bool loadNetwork(std::shared_ptr<ov::Model> network, const std::string& ir_xml, const std::string& ir_bin) = 0;
+    virtual void loadNetwork(const std::string& model_name) = 0;
+    virtual bool createNetwork(std::shared_ptr<ov::Model> network, const std::string& ir_xml, const std::string& ir_bin) = 0;
     virtual ov::InferRequest getInferRequest() = 0;
     virtual void infer() = 0;
-    virtual void queryState() = 0;
+    virtual bool queryState() = 0;
     virtual ov::Tensor getTensor(const std::string& outName) = 0;
     virtual ov::Tensor getInputTensor(const std::size_t index) = 0;
     virtual ov::Tensor getOutputTensor(const std::size_t index) = 0;
@@ -35,17 +36,19 @@ class IENetwork : public IIENetwork {
 private:
     IntelDeviceType mTargetDevice;
     ov::InferRequest mInferRequest;
+    bool isLoaded = false;
 
 public:
     IENetwork(IntelDeviceType device)
         : mTargetDevice(device) {}
 
-    virtual bool loadNetwork(std::shared_ptr<ov::Model> network, const std::string& ir_xml, const std::string& ir_bin);
+    virtual void loadNetwork(const std::string& model_name);
+    virtual bool createNetwork(std::shared_ptr<ov::Model> network, const std::string& ir_xml, const std::string& ir_bin);
     ov::Tensor getTensor(const std::string& outName);
     ov::Tensor getInputTensor(const std::size_t index);
     ov::Tensor getOutputTensor(const std::size_t index);
     ov::InferRequest getInferRequest() { return mInferRequest; }
-    void queryState() {}
+    bool queryState() { return isLoaded; }
     void infer();
     bool getGrpcIpPort(char *ip_port);
 };

--- a/ModelManager.h
+++ b/ModelManager.h
@@ -167,7 +167,9 @@ public:
     T GetConstFromBuffer(const uint8_t* buf, uint32_t len);
 
     void* getBlobFromMemoryPoolIn(const Request& request, uint32_t index, uint32_t& rBufferLength);
+    void* getBlobFromMemoryPoolIn(const V1_3::Request& request, uint32_t index, uint32_t& rBufferLength);
     void* getBlobFromMemoryPoolOut(const Request& request, uint32_t index, uint32_t& rBufferLength);
+    void* getBlobFromMemoryPoolOut(const V1_3::Request& request, uint32_t index, uint32_t& rBufferLength);
 
     Model getModel() { return mModel; }
 

--- a/ModelManager.h
+++ b/ModelManager.h
@@ -187,10 +187,11 @@ public:
 
     std::vector<V1_2::OutputShape> getOutputShapes() { return mOutputShapes; }
 
-    void unmapRuntimeMemPools() {
+    bool unmapRuntimeMemPools() {
         for (auto& runtimeInfo : mRequestPoolInfos) {
             runtimeInfo.unmap_mem();
         }
+        return true;
     }
 
     bool isOmittedInput(int operationIndex, uint32_t index);

--- a/ngraph_creator/Android.bp
+++ b/ngraph_creator/Android.bp
@@ -35,6 +35,7 @@ cc_library_static {
         "operations/src/Greater.cpp",
         "operations/src/GreaterEqual.cpp",
         "operations/src/GroupedConv2d.cpp",
+        "operations/src/HardSwish.cpp",
         "operations/src/InstanceNormalization.cpp",
         "operations/src/L2Normalization.cpp",
         "operations/src/L2Pooling2D.cpp",

--- a/ngraph_creator/include/OperationsFactory.hpp
+++ b/ngraph_creator/include/OperationsFactory.hpp
@@ -25,6 +25,7 @@
 #include <Greater.hpp>
 #include <GreaterEqual.hpp>
 #include <GroupedConv2d.hpp>
+#include <HardSwish.hpp>
 #include <InstanceNormalization.hpp>
 #include <L2Normalization.hpp>
 #include <L2Pooling2D.hpp>

--- a/ngraph_creator/include/OperationsFactory.hpp
+++ b/ngraph_creator/include/OperationsFactory.hpp
@@ -90,6 +90,7 @@ namespace nnhal {
 class OperationsFactory {
 private:
     std::shared_ptr<NgraphNodes> mNgraphNodes;
+    GraphMetadata mGraphMetadata;
 
 public:
     OperationsFactory(IntelDeviceType deviceType, std::shared_ptr<NnapiModelInfo> modelInfo,

--- a/ngraph_creator/operations/include/Abs.hpp
+++ b/ngraph_creator/operations/include/Abs.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Abs : public OperationsBase {
 public:
-    Abs(int operationIndex);
+    Abs(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Add.hpp
+++ b/ngraph_creator/operations/include/Add.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Add : public OperationsBase {
 public:
-    Add(int operationIndex);
+    Add(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
     std::shared_ptr<ov::Node> createNodeForPlugin() override;

--- a/ngraph_creator/operations/include/Argmax.hpp
+++ b/ngraph_creator/operations/include/Argmax.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Argmax : public OperationsBase {
 public:
-    Argmax(int operationIndex);
+    Argmax(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Argmin.hpp
+++ b/ngraph_creator/operations/include/Argmin.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Argmin : public OperationsBase {
 public:
-    Argmin(int operationIndex);
+    Argmin(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/AveragePool2D.hpp
+++ b/ngraph_creator/operations/include/AveragePool2D.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class AveragePool2D : public OperationsBase {
 public:
-    AveragePool2D(int operationIndex);
+    AveragePool2D(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/BatchToSpace.hpp
+++ b/ngraph_creator/operations/include/BatchToSpace.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class BatchToSpace : public OperationsBase {
 public:
-    BatchToSpace(int operationIndex);
+    BatchToSpace(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/BidirectionalSequenceRNN.hpp
+++ b/ngraph_creator/operations/include/BidirectionalSequenceRNN.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class BidirectionalSequenceRNN : public OperationsBase {
 public:
-    BidirectionalSequenceRNN(int operationIndex);
+    BidirectionalSequenceRNN(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
     void connectOperationToGraph() override;
     bool isValidInputTensor(uint32_t inputIndex);

--- a/ngraph_creator/operations/include/Cast.hpp
+++ b/ngraph_creator/operations/include/Cast.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Cast : public OperationsBase {
 public:
-    Cast(int operationIndex);
+    Cast(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
     void connectOperationToGraph() override;
 };

--- a/ngraph_creator/operations/include/ChannelShuffle.hpp
+++ b/ngraph_creator/operations/include/ChannelShuffle.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class ChannelShuffle : public OperationsBase {
 public:
-    ChannelShuffle(int operationIndex);
+    ChannelShuffle(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/Concat.hpp
+++ b/ngraph_creator/operations/include/Concat.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Concat : public OperationsBase {
 public:
-    Concat(int operationIndex);
+    Concat(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/Conv2d.hpp
+++ b/ngraph_creator/operations/include/Conv2d.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Conv2d : public OperationsBase {
 public:
-    Conv2d(int operationIndex);
+    Conv2d(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/DepthToSpace.hpp
+++ b/ngraph_creator/operations/include/DepthToSpace.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class DepthToSpace : public OperationsBase {
 public:
-    DepthToSpace(int operationIndex);
+    DepthToSpace(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/DepthwiseConv2d.hpp
+++ b/ngraph_creator/operations/include/DepthwiseConv2d.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class DepthwiseConv2d : public OperationsBase {
 public:
-    DepthwiseConv2d(int operationIndex);
+    DepthwiseConv2d(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/Dequantize.hpp
+++ b/ngraph_creator/operations/include/Dequantize.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Dequantize : public OperationsBase {
 public:
-    Dequantize(int operationIndex);
+    Dequantize(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Div.hpp
+++ b/ngraph_creator/operations/include/Div.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Div : public OperationsBase {
 public:
-    Div(int operationIndex);
+    Div(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/EmbeddingLookup.hpp
+++ b/ngraph_creator/operations/include/EmbeddingLookup.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class EmbeddingLookup : public OperationsBase {
 public:
-    EmbeddingLookup(int operationIndex);
+    EmbeddingLookup(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/Equal.hpp
+++ b/ngraph_creator/operations/include/Equal.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Equal : public OperationsBase {
 public:
-    Equal(int operationIndex);
+    Equal(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Exp.hpp
+++ b/ngraph_creator/operations/include/Exp.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Exp : public OperationsBase {
 public:
-    Exp(int operationIndex);
+    Exp(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/ExpandDims.hpp
+++ b/ngraph_creator/operations/include/ExpandDims.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class ExpandDims : public OperationsBase {
 public:
-    ExpandDims(int operationIndex);
+    ExpandDims(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/Floor.hpp
+++ b/ngraph_creator/operations/include/Floor.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Floor : public OperationsBase {
 public:
-    Floor(int operationIndex);
+    Floor(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/FullyConnected.hpp
+++ b/ngraph_creator/operations/include/FullyConnected.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class FullyConnected : public OperationsBase {
 public:
-    FullyConnected(int operationIndex);
+    FullyConnected(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/Gather.hpp
+++ b/ngraph_creator/operations/include/Gather.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Gather : public OperationsBase {
 public:
-    Gather(int operationIndex);
+    Gather(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Greater.hpp
+++ b/ngraph_creator/operations/include/Greater.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Greater : public OperationsBase {
 public:
-    Greater(int operationIndex);
+    Greater(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/GreaterEqual.hpp
+++ b/ngraph_creator/operations/include/GreaterEqual.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class GreaterEqual : public OperationsBase {
 public:
-    GreaterEqual(int operationIndex);
+    GreaterEqual(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/GroupedConv2d.hpp
+++ b/ngraph_creator/operations/include/GroupedConv2d.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class GroupedConv2d : public OperationsBase {
 public:
-    GroupedConv2d(int operationIndex);
+    GroupedConv2d(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/HardSwish.hpp
+++ b/ngraph_creator/operations/include/HardSwish.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class HardSwish : public OperationsBase {
 public:
-    HardSwish(int operationIndex);
+    HardSwish(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/HardSwish.hpp
+++ b/ngraph_creator/operations/include/HardSwish.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <OperationsBase.hpp>
+
+namespace android {
+namespace hardware {
+namespace neuralnetworks {
+namespace nnhal {
+
+class HardSwish : public OperationsBase {
+public:
+    HardSwish(int operationIndex);
+    bool validate() override;
+    std::shared_ptr<ov::Node> createNode() override;
+};
+
+}  // namespace nnhal
+}  // namespace neuralnetworks
+}  // namespace hardware
+}  // namespace android

--- a/ngraph_creator/operations/include/InstanceNormalization.hpp
+++ b/ngraph_creator/operations/include/InstanceNormalization.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class InstanceNormalization : public OperationsBase {
 public:
-    InstanceNormalization(int operationIndex);
+    InstanceNormalization(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/L2Normalization.hpp
+++ b/ngraph_creator/operations/include/L2Normalization.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class L2Normalization : public OperationsBase {
 public:
-    L2Normalization(int operationIndex);
+    L2Normalization(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/L2Pooling2D.hpp
+++ b/ngraph_creator/operations/include/L2Pooling2D.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class L2Pooling2D : public OperationsBase {
 public:
-    L2Pooling2D(int operationIndex);
+    L2Pooling2D(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/LSTM.hpp
+++ b/ngraph_creator/operations/include/LSTM.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class LSTM : public OperationsBase {
 public:
-    LSTM(int operationIndex);
+    LSTM(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
     void connectOperationToGraph() override;

--- a/ngraph_creator/operations/include/Less.hpp
+++ b/ngraph_creator/operations/include/Less.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Less : public OperationsBase {
 public:
-    Less(int operationIndex);
+    Less(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/LessEqual.hpp
+++ b/ngraph_creator/operations/include/LessEqual.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class LessEqual : public OperationsBase {
 public:
-    LessEqual(int operationIndex);
+    LessEqual(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Log.hpp
+++ b/ngraph_creator/operations/include/Log.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Log : public OperationsBase {
 public:
-    Log(int operationIndex);
+    Log(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/LogSoftmax.hpp
+++ b/ngraph_creator/operations/include/LogSoftmax.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class LogSoftmax : public OperationsBase {
 public:
-    LogSoftmax(int operationIndex);
+    LogSoftmax(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/LogicalAnd.hpp
+++ b/ngraph_creator/operations/include/LogicalAnd.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class LogicalAnd : public OperationsBase {
 public:
-    LogicalAnd(int operationIndex);
+    LogicalAnd(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/LogicalNot.hpp
+++ b/ngraph_creator/operations/include/LogicalNot.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class LogicalNot : public OperationsBase {
 public:
-    LogicalNot(int operationIndex);
+    LogicalNot(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/LogicalOr.hpp
+++ b/ngraph_creator/operations/include/LogicalOr.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class LogicalOr : public OperationsBase {
 public:
-    LogicalOr(int operationIndex);
+    LogicalOr(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Logistic.hpp
+++ b/ngraph_creator/operations/include/Logistic.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Logistic : public OperationsBase {
 public:
-    Logistic(int operationIndex);
+    Logistic(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/MaxPool2d.hpp
+++ b/ngraph_creator/operations/include/MaxPool2d.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class MaxPool2d : public OperationsBase {
 public:
-    MaxPool2d(int operationIndex);
+    MaxPool2d(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Maximum.hpp
+++ b/ngraph_creator/operations/include/Maximum.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Maximum : public OperationsBase {
 public:
-    Maximum(int operationIndex);
+    Maximum(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Mean.hpp
+++ b/ngraph_creator/operations/include/Mean.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Mean : public OperationsBase {
 public:
-    Mean(int operationIndex);
+    Mean(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/Minimum.hpp
+++ b/ngraph_creator/operations/include/Minimum.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Minimum : public OperationsBase {
 public:
-    Minimum(int operationIndex);
+    Minimum(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Mul.hpp
+++ b/ngraph_creator/operations/include/Mul.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Mul : public OperationsBase {
 public:
-    Mul(int operationIndex);
+    Mul(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Neg.hpp
+++ b/ngraph_creator/operations/include/Neg.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Neg : public OperationsBase {
 public:
-    Neg(int operationIndex);
+    Neg(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/NotEqual.hpp
+++ b/ngraph_creator/operations/include/NotEqual.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class NotEqual : public OperationsBase {
 public:
-    NotEqual(int operationIndex);
+    NotEqual(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/OperationsBase.hpp
+++ b/ngraph_creator/operations/include/OperationsBase.hpp
@@ -50,6 +50,8 @@ protected:
     // helper functions
     bool checkOperandType(uint32_t operandIndex, const int32_t expectedOperandType,
                           const std::string& strLogInfo = "Operand");
+    //index should be the argument index number of outputs
+    //(if there are 4 outputs and want to check type for the 1st output index will be 0)
     bool checkOutputOperandType(uint32_t index, const int32_t expectedOperandType);
     bool checkInputOperandType(uint32_t index, const int32_t expectedOperandType);
     const vec<uint32_t> getInputOperandDimensions(uint32_t inputIndex);

--- a/ngraph_creator/operations/include/OperationsBase.hpp
+++ b/ngraph_creator/operations/include/OperationsBase.hpp
@@ -19,6 +19,11 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
+struct GraphMetadata {
+    std::shared_ptr<NnapiModelInfo> modelInfo;
+    IntelDeviceType pluginType;
+};
+
 class OperationsBase {
 protected:
     enum ConversionType {
@@ -43,7 +48,7 @@ protected:
     int mNnapiOperationIndex;
     std::shared_ptr<ov::Node> transpose(ConversionType type, ov::Output<ov::Node> input);
     virtual std::shared_ptr<ov::Node> createNode() = 0;
-    // override createNodeForPlugin in case sPluginType specific implementation is required
+    // override createNodeForPlugin in case mPluginType specific implementation is required
     virtual std::shared_ptr<ov::Node> createNodeForPlugin();
     void addResultNode(size_t index, std::shared_ptr<ov::Node> resultNode);
 
@@ -59,33 +64,33 @@ protected:
 
     std::shared_ptr<ov::Node> getInputNode(uint32_t inputIndex, bool dequantize = true) {
         std::shared_ptr<ov::Node> input;
-        auto operandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, inputIndex);
-        auto operandType = sModelInfo->getOperandType(operandIndex);
-        if (sModelInfo->isOperandLifeTimeConst(operandIndex)) {
+        auto operandIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, inputIndex);
+        auto operandType = mOpModelInfo->getOperandType(operandIndex);
+        if (mOpModelInfo->isOperandLifeTimeConst(operandIndex)) {
             auto operandDims = getInputOperandDimensions(inputIndex);
             ov::element::Type elementType;
             switch (operandType) {
                 case OperandType::TENSOR_FLOAT32: {
                     elementType = ov::element::f32;
-                    auto operandValues = sModelInfo->GetConstVecOperand<float>(operandIndex);
+                    auto operandValues = mOpModelInfo->GetConstVecOperand<float>(operandIndex);
                     input = createConstNode(elementType, toNgraphShape(operandDims), operandValues);
                     break;
                 }
                 case OperandType::TENSOR_INT32: {
                     elementType = ov::element::i32;
-                    auto operandValues = sModelInfo->GetConstVecOperand<int>(operandIndex);
+                    auto operandValues = mOpModelInfo->GetConstVecOperand<int>(operandIndex);
                     input = createConstNode(elementType, toNgraphShape(operandDims), operandValues);
                     break;
                 }
                 case OperandType::TENSOR_BOOL8: {
                     elementType = ov::element::boolean;
-                    auto operandValues = sModelInfo->GetConstVecOperand<uint8_t>(operandIndex);
+                    auto operandValues = mOpModelInfo->GetConstVecOperand<uint8_t>(operandIndex);
                     input = createConstNode(elementType, toNgraphShape(operandDims), operandValues);
                     break;
                 }
                 case OperandType::TENSOR_QUANT8_ASYMM: {
                     elementType = ov::element::u8;
-                    auto operandValues = sModelInfo->GetConstVecOperand<uint8_t>(operandIndex);
+                    auto operandValues = mOpModelInfo->GetConstVecOperand<uint8_t>(operandIndex);
                     input = createConstNode(elementType, toNgraphShape(operandDims), operandValues);
                     break;
                 }
@@ -93,25 +98,25 @@ protected:
                 case OperandType::TENSOR_QUANT8_SYMM_PER_CHANNEL:
                 case OperandType::TENSOR_QUANT8_ASYMM_SIGNED: {
                     elementType = ov::element::i8;
-                    auto operandValues = sModelInfo->GetConstVecOperand<int8_t>(operandIndex);
+                    auto operandValues = mOpModelInfo->GetConstVecOperand<int8_t>(operandIndex);
                     input = createConstNode(elementType, toNgraphShape(operandDims), operandValues);
                     break;
                 }
                 case OperandType::TENSOR_FLOAT16: {
                     elementType = ov::element::f16;
-                    auto operandValues = sModelInfo->GetConstVecOperand<_Float16>(operandIndex);
+                    auto operandValues = mOpModelInfo->GetConstVecOperand<_Float16>(operandIndex);
                     input = createConstNode(elementType, toNgraphShape(operandDims), operandValues);
                     break;
                 }
                 case OperandType::TENSOR_QUANT16_SYMM: {
                     elementType = ov::element::i16;
-                    auto operandValues = sModelInfo->GetConstVecOperand<int16_t>(operandIndex);
+                    auto operandValues = mOpModelInfo->GetConstVecOperand<int16_t>(operandIndex);
                     input = createConstNode(elementType, toNgraphShape(operandDims), operandValues);
                     break;
                 }
                 case OperandType::TENSOR_QUANT16_ASYMM: {
                     elementType = ov::element::u16;
-                    auto operandValues = sModelInfo->GetConstVecOperand<uint16_t>(operandIndex);
+                    auto operandValues = mOpModelInfo->GetConstVecOperand<uint16_t>(operandIndex);
                     input = createConstNode(elementType, toNgraphShape(operandDims), operandValues);
                     break;
                 }
@@ -141,7 +146,7 @@ protected:
     }
     // remove null input node parameter
     void removeInputNode(uint32_t inputIndex) {
-        auto operandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, inputIndex);
+        auto operandIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, inputIndex);
         auto nodeName = mNgraphNodes->getNodeName(operandIndex);
         mNgraphNodes->removeInputParameter(nodeName, operandIndex);
     }
@@ -166,18 +171,18 @@ protected:
                                              ov::element::Type dequantizeType);
 
     const Operand& getInputOperand(uint32_t index) {
-        auto inputIdx = sModelInfo->getOperationInput(mNnapiOperationIndex, index);
-        return sModelInfo->getOperand(inputIdx);
+        auto inputIdx = mOpModelInfo->getOperationInput(mNnapiOperationIndex, index);
+        return mOpModelInfo->getOperand(inputIdx);
     }
 
     const Operand& getOutputOperand(uint32_t index) {
-        auto outputIdx = sModelInfo->getOperationOutput(mNnapiOperationIndex, index);
-        return sModelInfo->getOperand(outputIdx);
+        auto outputIdx = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, index);
+        return mOpModelInfo->getOperand(outputIdx);
     }
 
     bool isZeroSizedInput(uint32_t index) {
-        auto inputIdx = sModelInfo->getOperationInput(mNnapiOperationIndex, index);
-        auto operand = sModelInfo->getOperand(inputIdx);
+        auto inputIdx = mOpModelInfo->getOperationInput(mNnapiOperationIndex, index);
+        auto operand = mOpModelInfo->getOperand(inputIdx);
         auto& dims = operand.dimensions;
 
         if ((dims.size() > 0) && (dims[0] != 0)) return false;
@@ -186,14 +191,14 @@ protected:
     }
 
 public:
-    static std::shared_ptr<NnapiModelInfo> sModelInfo;
-    static IntelDeviceType sPluginType;
+    std::shared_ptr<NnapiModelInfo> mOpModelInfo;
+    IntelDeviceType mPluginType;
     std::shared_ptr<NgraphNodes> mNgraphNodes;
-    OperationsBase(int operationIndex);
+    OperationsBase(int operationIndex, GraphMetadata graphMetadata = {});
     void setNgraphNodes(std::shared_ptr<NgraphNodes> nodes);
     bool transposed = false;
     virtual bool validate();
-    // override validateForPlugin in case sPluginType specific implementation is required
+    // override validateForPlugin in case mPluginType specific implementation is required
     virtual bool validateForPlugin();
     // override connectOperationToGraph in case Operation has multiple outputs
     virtual void connectOperationToGraph();

--- a/ngraph_creator/operations/include/PRelu.hpp
+++ b/ngraph_creator/operations/include/PRelu.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class PRelu : public OperationsBase {
 public:
-    PRelu(int operationIndex);
+    PRelu(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/Pad.hpp
+++ b/ngraph_creator/operations/include/Pad.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Pad : public OperationsBase {
 public:
-    Pad(int operationIndex);
+    Pad(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/PadV2.hpp
+++ b/ngraph_creator/operations/include/PadV2.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class PadV2 : public OperationsBase {
 public:
-    PadV2(int operationIndex);
+    PadV2(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/Pow.hpp
+++ b/ngraph_creator/operations/include/Pow.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Pow : public OperationsBase {
 public:
-    Pow(int operationIndex);
+    Pow(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Quantize.hpp
+++ b/ngraph_creator/operations/include/Quantize.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Quantize : public OperationsBase {
 public:
-    Quantize(int operationIndex);
+    Quantize(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
     void connectOperationToGraph() override;
 };

--- a/ngraph_creator/operations/include/RNN.hpp
+++ b/ngraph_creator/operations/include/RNN.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class RNN : public OperationsBase {
 public:
-    RNN(int operationIndex);
+    RNN(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
     void connectOperationToGraph() override;
 };

--- a/ngraph_creator/operations/include/ROIAlign.hpp
+++ b/ngraph_creator/operations/include/ROIAlign.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class ROIAlign : public OperationsBase {
 public:
-    ROIAlign(int operationIndex);
+    ROIAlign(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/ROIPooling.hpp
+++ b/ngraph_creator/operations/include/ROIPooling.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class ROIPooling : public OperationsBase {
 public:
-    ROIPooling(int operationIndex);
+    ROIPooling(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/RSQRT.hpp
+++ b/ngraph_creator/operations/include/RSQRT.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class RSQRT : public OperationsBase {
 public:
-    RSQRT(int operationIndex);
+    RSQRT(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/ReduceAll.hpp
+++ b/ngraph_creator/operations/include/ReduceAll.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class ReduceAll : public OperationsBase {
 public:
-    ReduceAll(int operationIndex);
+    ReduceAll(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/ReduceAny.hpp
+++ b/ngraph_creator/operations/include/ReduceAny.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class ReduceAny : public OperationsBase {
 public:
-    ReduceAny(int operationIndex);
+    ReduceAny(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/ReduceMax.hpp
+++ b/ngraph_creator/operations/include/ReduceMax.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class ReduceMax : public OperationsBase {
 public:
-    ReduceMax(int operationIndex);
+    ReduceMax(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/ReduceMin.hpp
+++ b/ngraph_creator/operations/include/ReduceMin.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class ReduceMin : public OperationsBase {
 public:
-    ReduceMin(int operationIndex);
+    ReduceMin(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/ReduceProd.hpp
+++ b/ngraph_creator/operations/include/ReduceProd.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class ReduceProd : public OperationsBase {
 public:
-    ReduceProd(int operationIndex);
+    ReduceProd(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/ReduceSum.hpp
+++ b/ngraph_creator/operations/include/ReduceSum.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class ReduceSum : public OperationsBase {
 public:
-    ReduceSum(int operationIndex);
+    ReduceSum(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Relu.hpp
+++ b/ngraph_creator/operations/include/Relu.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Relu : public OperationsBase {
 public:
-    Relu(int operationIndex);
+    Relu(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Relu1.hpp
+++ b/ngraph_creator/operations/include/Relu1.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Relu1 : public OperationsBase {
 public:
-    Relu1(int operationIndex);
+    Relu1(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Relu6.hpp
+++ b/ngraph_creator/operations/include/Relu6.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Relu6 : public OperationsBase {
 public:
-    Relu6(int operationIndex);
+    Relu6(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Reshape.hpp
+++ b/ngraph_creator/operations/include/Reshape.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Reshape : public OperationsBase {
 public:
-    Reshape(int operationIndex);
+    Reshape(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/ResizeBilinear.hpp
+++ b/ngraph_creator/operations/include/ResizeBilinear.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class ResizeBilinear : public OperationsBase {
 public:
-    ResizeBilinear(int operationIndex);
+    ResizeBilinear(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/ResizeNearestNeighbor.hpp
+++ b/ngraph_creator/operations/include/ResizeNearestNeighbor.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class ResizeNearestNeighbor : public OperationsBase {
 public:
-    ResizeNearestNeighbor(int operationIndex);
+    ResizeNearestNeighbor(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/SQRT.hpp
+++ b/ngraph_creator/operations/include/SQRT.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class SQRT : public OperationsBase {
 public:
-    SQRT(int operationIndex);
+    SQRT(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Select.hpp
+++ b/ngraph_creator/operations/include/Select.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Select : public OperationsBase {
 public:
-    Select(int operationIndex);
+    Select(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Sin.hpp
+++ b/ngraph_creator/operations/include/Sin.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Sin : public OperationsBase {
 public:
-    Sin(int operationIndex);
+    Sin(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Softmax.hpp
+++ b/ngraph_creator/operations/include/Softmax.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Softmax : public OperationsBase {
 public:
-    Softmax(int operationIndex);
+    Softmax(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/SpaceToBatch.hpp
+++ b/ngraph_creator/operations/include/SpaceToBatch.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class SpaceToBatch : public OperationsBase {
 public:
-    SpaceToBatch(int operationIndex);
+    SpaceToBatch(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/SpaceToDepth.hpp
+++ b/ngraph_creator/operations/include/SpaceToDepth.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class SpaceToDepth : public OperationsBase {
 public:
-    SpaceToDepth(int operationIndex);
+    SpaceToDepth(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Split.hpp
+++ b/ngraph_creator/operations/include/Split.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Split : public OperationsBase {
 public:
-    Split(int operationIndex);
+    Split(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
     void connectOperationToGraph() override;
 };

--- a/ngraph_creator/operations/include/Squeeze.hpp
+++ b/ngraph_creator/operations/include/Squeeze.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Squeeze : public OperationsBase {
 public:
-    Squeeze(int operationIndex);
+    Squeeze(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/StridedSlice.hpp
+++ b/ngraph_creator/operations/include/StridedSlice.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class StridedSlice : public OperationsBase {
 public:
-    StridedSlice(int operationIndex);
+    StridedSlice(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
     std::vector<int64_t> getMaskBits(int32_t maskValue, size_t vec_size);

--- a/ngraph_creator/operations/include/Sub.hpp
+++ b/ngraph_creator/operations/include/Sub.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Sub : public OperationsBase {
 public:
-    Sub(int operationIndex);
+    Sub(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/Tanh.hpp
+++ b/ngraph_creator/operations/include/Tanh.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Tanh : public OperationsBase {
 public:
-    Tanh(int operationIndex);
+    Tanh(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
 };
 

--- a/ngraph_creator/operations/include/TopkV2.hpp
+++ b/ngraph_creator/operations/include/TopkV2.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class TopkV2 : public OperationsBase {
 public:
-    TopkV2(int operationIndex);
+    TopkV2(int operationIndex, GraphMetadata graphMetadata);
     std::shared_ptr<ov::Node> createNode() override;
     void connectOperationToGraph() override;
 };

--- a/ngraph_creator/operations/include/Transpose.hpp
+++ b/ngraph_creator/operations/include/Transpose.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class Transpose : public OperationsBase {
 public:
-    Transpose(int operationIndex);
+    Transpose(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/TransposeConv2D.hpp
+++ b/ngraph_creator/operations/include/TransposeConv2D.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class TransposeConv2D : public OperationsBase {
 public:
-    TransposeConv2D(int operationIndex);
+    TransposeConv2D(int operationIndex, GraphMetadata graphMetadata);
     bool validate() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/include/UnidirectionalSequenceRNN.hpp
+++ b/ngraph_creator/operations/include/UnidirectionalSequenceRNN.hpp
@@ -9,7 +9,7 @@ namespace nnhal {
 
 class UnidirectionalSequenceRNN : public OperationsBase {
 public:
-    UnidirectionalSequenceRNN(int operationIndex);
+    UnidirectionalSequenceRNN(int operationIndex, GraphMetadata graphMetadata);
     void connectOperationToGraph() override;
     std::shared_ptr<ov::Node> createNode() override;
 };

--- a/ngraph_creator/operations/src/Abs.cpp
+++ b/ngraph_creator/operations/src/Abs.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Abs::Abs(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Abs::Abs(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Abs::createNode() {

--- a/ngraph_creator/operations/src/Argmax.cpp
+++ b/ngraph_creator/operations/src/Argmax.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Argmax::Argmax(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Argmax::Argmax(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Argmax::createNode() {
@@ -17,7 +17,7 @@ std::shared_ptr<ov::Node> Argmax::createNode() {
 
     input = getInputNode(0);
 
-    int32_t axis = sModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 1);
+    int32_t axis = mOpModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 1);
     ALOGD("createNode axis %d", axis);
 
     auto k_node = createConstNode(ov::element::i32, {}, convertToVector(1));

--- a/ngraph_creator/operations/src/Argmin.cpp
+++ b/ngraph_creator/operations/src/Argmin.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Argmin::Argmin(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Argmin::Argmin(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Argmin::createNode() {
@@ -17,7 +17,7 @@ std::shared_ptr<ov::Node> Argmin::createNode() {
 
     input = getInputNode(0);
 
-    int32_t axis = sModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 1);
+    int32_t axis = mOpModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 1);
     ALOGD("createNode axis %d", axis);
 
     auto k_node = createConstNode(ov::element::i32, {}, convertToVector(1));

--- a/ngraph_creator/operations/src/AveragePool2D.cpp
+++ b/ngraph_creator/operations/src/AveragePool2D.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-AveragePool2D::AveragePool2D(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+AveragePool2D::AveragePool2D(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 bool AveragePool2D::validate() {
@@ -26,7 +26,7 @@ bool AveragePool2D::validate() {
 std::shared_ptr<ov::Node> AveragePool2D::createNode() {
     std::shared_ptr<ov::Node> inputNode;
     const auto& inDims = getInputOperandDimensions(0);
-    const auto& inputsSize = sModelInfo->getOperationInputsSize(mNnapiOperationIndex);
+    const auto& inputsSize = mOpModelInfo->getOperationInputsSize(mNnapiOperationIndex);
 
     inputNode = getInputNode(0);
 
@@ -59,21 +59,21 @@ std::shared_ptr<ov::Node> AveragePool2D::createNode() {
     }
 
     if (isExplicit) {
-        padding_left = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 1);
-        padding_right = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
-        padding_top = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 3);
-        padding_bottom = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 4);
+        padding_left = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 1);
+        padding_right = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
+        padding_top = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 3);
+        padding_bottom = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 4);
 
-        stride_width = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 5);
-        stride_height = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 6);
+        stride_width = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 5);
+        stride_height = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 6);
 
-        filter_width = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 7);
-        filter_height = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 8);
+        filter_width = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 7);
+        filter_height = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 8);
 
-        activationFn = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 9);
+        activationFn = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 9);
 
         if (inputsSize == 11) {
-            layout = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 10);
+            layout = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 10);
         }
 
         if (layout) useNchw = true;
@@ -82,18 +82,18 @@ std::shared_ptr<ov::Node> AveragePool2D::createNode() {
     }
 
     if (isImplicit) {
-        padding_scheme = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 1);
+        padding_scheme = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 1);
 
-        stride_width = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
-        stride_height = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 3);
+        stride_width = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
+        stride_height = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 3);
 
-        filter_width = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 4);
-        filter_height = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 5);
+        filter_width = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 4);
+        filter_height = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 5);
 
-        activationFn = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 6);
+        activationFn = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 6);
 
         if (inputsSize == 8) {
-            layout = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 7);
+            layout = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 7);
         }
 
         if (layout) useNchw = true;

--- a/ngraph_creator/operations/src/BatchToSpace.cpp
+++ b/ngraph_creator/operations/src/BatchToSpace.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-BatchToSpace::BatchToSpace(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+BatchToSpace::BatchToSpace(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 bool BatchToSpace::validate() {
@@ -17,10 +17,10 @@ bool BatchToSpace::validate() {
 
     if (inputRank != 4) return false;
 
-    const auto& block_shape_OperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+    const auto& block_shape_OperandIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 1);
 
     // TODO: Add Support for all_tensors_as_inputs
-    if (!sModelInfo->isOperandLifeTimeConst(block_shape_OperandIndex)) {
+    if (!mOpModelInfo->isOperandLifeTimeConst(block_shape_OperandIndex)) {
         ALOGE("%s Only Constant dimensions supported now", __func__);
         return false;
     }
@@ -32,19 +32,19 @@ bool BatchToSpace::validate() {
 std::shared_ptr<ov::Node> BatchToSpace::createNode() {
     int32_t layout = 0;
     bool useNchw = false;
-    const auto& inputsSize = sModelInfo->getOperationInputsSize(mNnapiOperationIndex);
+    const auto& inputsSize = mOpModelInfo->getOperationInputsSize(mNnapiOperationIndex);
     ALOGD("%s inputsSize %lu", __func__, inputsSize);
 
     auto inputNode = getInputNode(0);
     auto& inDims = getInputOperandDimensions(0);
-    const auto& block_shape_OperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
-    auto block_shape = sModelInfo->GetConstVecOperand<int32_t>(block_shape_OperandIndex);
+    const auto& block_shape_OperandIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+    auto block_shape = mOpModelInfo->GetConstVecOperand<int32_t>(block_shape_OperandIndex);
 
     // Compensation for the shape to be same as the size of data input shape
     block_shape.insert(block_shape.begin(), 1);
     block_shape.insert(block_shape.begin(), 1);
 
-    if (inputsSize == 3) layout = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
+    if (inputsSize == 3) layout = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
     if (layout) useNchw = true;
 
     std::vector<uint32_t> shape(inDims.size(), 0);

--- a/ngraph_creator/operations/src/BidirectionalSequenceRNN.cpp
+++ b/ngraph_creator/operations/src/BidirectionalSequenceRNN.cpp
@@ -9,9 +9,9 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-BidirectionalSequenceRNN::BidirectionalSequenceRNN(int operationIndex)
+BidirectionalSequenceRNN::BidirectionalSequenceRNN(int operationIndex, GraphMetadata graphMetadata)
     : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 void BidirectionalSequenceRNN::connectOperationToGraph() { createNode(); }
@@ -50,9 +50,9 @@ std::shared_ptr<ov::Node> BidirectionalSequenceRNN::createNode() {
         hasAuxInputs = true;
     }
 
-    auto activationFn = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 12);
-    auto isTimeMajor = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 13);
-    auto mergeOutputs = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 14);
+    auto activationFn = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 12);
+    auto isTimeMajor = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 13);
+    auto mergeOutputs = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 14);
 
     const auto& inDims = getInputOperandDimensions(0);
     uint32_t maxTime;
@@ -206,15 +206,15 @@ std::shared_ptr<ov::Node> BidirectionalSequenceRNN::createNode() {
         fwOutputNode = std::make_shared<ov::opset3::Concat>(concat_output, 2);
     }
 
-    const auto& outputsSize = sModelInfo->getOperationOutputsSize(mNnapiOperationIndex);
+    const auto& outputsSize = mOpModelInfo->getOperationOutputsSize(mNnapiOperationIndex);
 
-    auto fwOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+    auto fwOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
     mNgraphNodes->setOutputAtOperandIndex(fwOutputIndex, fwOutputNode);
     ALOGD("%s Set Output index %d", __func__, fwOutputIndex);
-    const auto fwOp = sModelInfo->getOperand(fwOutputIndex);
+    const auto fwOp = mOpModelInfo->getOperand(fwOutputIndex);
 
     if (!mergeOutputs) {
-        auto bwOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 1);
+        auto bwOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 1);
         mNgraphNodes->setOutputAtOperandIndex(bwOutputIndex, bwOutputNode);
         ALOGD("%s Set Output index %d", __func__, bwOutputIndex);
     }
@@ -230,13 +230,13 @@ std::shared_ptr<ov::Node> BidirectionalSequenceRNN::createNode() {
         }
 
         auto forward_hidden_state_output_Index =
-            sModelInfo->getOperationOutput(mNnapiOperationIndex, fw_hidden_op_index);
+            mOpModelInfo->getOperationOutput(mNnapiOperationIndex, fw_hidden_op_index);
         mNgraphNodes->setOutputAtOperandIndex(forward_hidden_state_output_Index,
                                               fw_op_lastTimestep);
         ALOGD("%s Set Output index %d", __func__, forward_hidden_state_output_Index);
 
         auto backward_hidden_state_output_Index =
-            sModelInfo->getOperationOutput(mNnapiOperationIndex, bw_hidden_op_index);
+            mOpModelInfo->getOperationOutput(mNnapiOperationIndex, bw_hidden_op_index);
         mNgraphNodes->setOutputAtOperandIndex(backward_hidden_state_output_Index,
                                               bw_op_lastTimestep);
         ALOGD("%s Set Output index %d", __func__, backward_hidden_state_output_Index);

--- a/ngraph_creator/operations/src/Cast.cpp
+++ b/ngraph_creator/operations/src/Cast.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Cast::Cast(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Cast::Cast(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 void Cast::connectOperationToGraph() { createNode(); }
@@ -19,11 +19,11 @@ std::shared_ptr<ov::Node> Cast::createNode() {
 
     input = getInputNode(0, false);
 
-    auto inputIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
-    auto outputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+    auto inputIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 0);
+    auto outputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 
-    const auto& inputType = sModelInfo->getOperandType(inputIndex);
-    const auto& outputType = sModelInfo->getOperandType(outputIndex);
+    const auto& inputType = mOpModelInfo->getOperandType(inputIndex);
+    const auto& outputType = mOpModelInfo->getOperandType(outputIndex);
 
     ov::element::Type elementType;  // change to outputbased element type
     std::shared_ptr<ov::Node> outputNode;

--- a/ngraph_creator/operations/src/ChannelShuffle.cpp
+++ b/ngraph_creator/operations/src/ChannelShuffle.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-ChannelShuffle::ChannelShuffle(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+ChannelShuffle::ChannelShuffle(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 bool ChannelShuffle::validate() {
@@ -20,7 +20,7 @@ bool ChannelShuffle::validate() {
     }
 
     // Check axis range
-    int64_t axis = sModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 2);
+    int64_t axis = mOpModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 2);
     if (!(axis >= -inputRank && axis < inputRank)) {
         ALOGE("%s Axis %ld not in the range [-inputRank, inputRank)", __func__, axis);
         return false;
@@ -32,8 +32,8 @@ bool ChannelShuffle::validate() {
 std::shared_ptr<ov::Node> ChannelShuffle::createNode() {
     // Creating input nodes
     auto inputNode = getInputNode(0);
-    int64_t group = sModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 1);
-    int64_t axis = sModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 2);
+    int64_t group = mOpModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 1);
+    int64_t axis = mOpModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 2);
 
     auto inputRank = getInputOperandDimensions(0).size();
     axis = (axis >= 0) ? axis : (axis + inputRank);

--- a/ngraph_creator/operations/src/Concat.cpp
+++ b/ngraph_creator/operations/src/Concat.cpp
@@ -7,13 +7,13 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Concat::Concat(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Concat::Concat(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 bool Concat::validate() {
     // check concatenation axis
-    auto n = sModelInfo->getOperationInputsSize(mNnapiOperationIndex) -
+    auto n = mOpModelInfo->getOperationInputsSize(mNnapiOperationIndex) -
              1;  // 0 ~ n-1: The list of n input tensors
     for (size_t i = 0; i < n; i++) {
         if (!isValidInputTensor(i)) {
@@ -26,16 +26,16 @@ bool Concat::validate() {
 }
 
 std::shared_ptr<ov::Node> Concat::createNode() {
-    auto n = sModelInfo->getOperationInputsSize(mNnapiOperationIndex) -
+    auto n = mOpModelInfo->getOperationInputsSize(mNnapiOperationIndex) -
              1;  // 0 ~ n-1: The list of n input tensors
-    auto axis = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex,
+    auto axis = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex,
                                                           n);  // n: concatenation axis
     std::vector<ov::Output<ov::Node>> inputs;
     ALOGV("createNode n %lu, axis %d", n, axis);
     for (size_t i = 0; i < n; i++) {
-        auto inputIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, i);
+        auto inputIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, i);
         auto inputOp = getInputNode(i);
-        const auto op = sModelInfo->getOperand(inputIndex);
+        const auto op = mOpModelInfo->getOperand(inputIndex);
         ALOGV("createNode inputIndex %d, lifetime %d", inputIndex, op.lifetime);
         inputs.push_back(inputOp);
     }

--- a/ngraph_creator/operations/src/DepthToSpace.cpp
+++ b/ngraph_creator/operations/src/DepthToSpace.cpp
@@ -7,23 +7,23 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-DepthToSpace::DepthToSpace(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+DepthToSpace::DepthToSpace(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> DepthToSpace::createNode() {
     // Creating input nodes
     std::shared_ptr<ov::Node> input;
     bool useNchw = false;
-    const auto& inputsSize = sModelInfo->getOperationInputsSize(mNnapiOperationIndex);
+    const auto& inputsSize = mOpModelInfo->getOperationInputsSize(mNnapiOperationIndex);
 
     if (inputsSize == 3) {
-        auto layout = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
+        auto layout = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
         if (layout) useNchw = true;
     }
 
     input = getInputNode(0);
-    auto block_size = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 1);
+    auto block_size = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 1);
 
     if (!useNchw)  // No conversion needed if useNchw set
         input = transpose(NHWC_NCHW, input);

--- a/ngraph_creator/operations/src/DepthwiseConv2d.cpp
+++ b/ngraph_creator/operations/src/DepthwiseConv2d.cpp
@@ -8,8 +8,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-DepthwiseConv2d::DepthwiseConv2d(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+DepthwiseConv2d::DepthwiseConv2d(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 bool DepthwiseConv2d::validate() {
@@ -29,8 +29,8 @@ bool DepthwiseConv2d::validate() {
     }
 
     if (checkInputOperandType(1, (int32_t)OperandType::TENSOR_QUANT8_SYMM_PER_CHANNEL)) {
-        const auto& operandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
-        const auto& operand = sModelInfo->getOperand(operandIndex);
+        const auto& operandIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+        const auto& operand = mOpModelInfo->getOperand(operandIndex);
         if (operand.extraParams.channelQuant().channelDim != 3) {
             return false;
         }
@@ -43,7 +43,7 @@ bool DepthwiseConv2d::validate() {
 std::shared_ptr<ov::Node> DepthwiseConv2d::createNode() {
     std::shared_ptr<ov::Node> inputNode;
     inputNode = getInputNode(0);
-    const auto& inputsSize = sModelInfo->getOperationInputsSize(mNnapiOperationIndex);
+    const auto& inputsSize = mOpModelInfo->getOperationInputsSize(mNnapiOperationIndex);
     ALOGD("%s inputsSize %lu", __func__, inputsSize);
     bool isImplicit = false, isExplicit = false;
 
@@ -83,30 +83,30 @@ std::shared_ptr<ov::Node> DepthwiseConv2d::createNode() {
     }
 
     if (isExplicit) {
-        padding_left = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 3);
-        padding_right = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 4);
-        padding_top = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 5);
-        padding_bottom = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 6);
+        padding_left = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 3);
+        padding_right = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 4);
+        padding_top = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 5);
+        padding_bottom = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 6);
 
-        stride_width = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 7);
-        stride_height = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 8);
+        stride_width = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 7);
+        stride_height = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 8);
 
-        depthwise_multiplier = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 9);
+        depthwise_multiplier = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 9);
 
-        activationFn = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 10);
+        activationFn = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 10);
 
         if (inputsSize > 11 && inputsSize <= 14) {
             switch (inputsSize) {
                 case 14:
                     dilation_height_factor =
-                        sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 13);
+                        mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 13);
                     __attribute__((fallthrough));
                 case 13:
                     dilation_width_factor =
-                        sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 12);
+                        mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 12);
                     __attribute__((fallthrough));
                 case 12:
-                    layout = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 11);
+                    layout = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 11);
                     __attribute__((fallthrough));
                 default:
                     break;
@@ -129,27 +129,27 @@ std::shared_ptr<ov::Node> DepthwiseConv2d::createNode() {
         }
     }
     else if (isImplicit) {
-        padding_scheme = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 3);
+        padding_scheme = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 3);
 
-        stride_width = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 4);
-        stride_height = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 5);
+        stride_width = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 4);
+        stride_height = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 5);
 
-        depthwise_multiplier = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 6);
+        depthwise_multiplier = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 6);
 
-        activationFn = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 7);
+        activationFn = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 7);
 
         if (inputsSize > 8 && inputsSize <= 11) {
             switch (inputsSize) {
                 case 11:
                     dilation_height_factor =
-                        sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 10);
+                        mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 10);
                     __attribute__((fallthrough));
                 case 10:
                     dilation_width_factor =
-                        sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 9);
+                        mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 9);
                     __attribute__((fallthrough));
                 case 9:
-                    layout = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 8);
+                    layout = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 8);
                     __attribute__((fallthrough));
                 default:
                     break;
@@ -186,16 +186,16 @@ std::shared_ptr<ov::Node> DepthwiseConv2d::createNode() {
     }
 
     std::shared_ptr<ov::Node> filterNode, biasNode;
-    const auto& biasIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 2);
+    const auto& biasIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 2);
 
     filterNode = getInputNode(1);
     biasNode = getInputNode(2);
 
     if (checkInputOperandType(1, (int32_t)OperandType::TENSOR_QUANT8_SYMM_PER_CHANNEL)) {
-        auto filterIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
-        const auto& filterOperand = sModelInfo->getOperand(filterIndex);
+        auto filterIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+        const auto& filterOperand = mOpModelInfo->getOperand(filterIndex);
         vec<float> filterScales = filterOperand.extraParams.channelQuant().scales;
-        float inputScale = sModelInfo->getOperandScale(0);
+        float inputScale = mOpModelInfo->getOperandScale(0);
         auto filterScalesNode =
             createConstNode(ov::element::f32, ov::Shape{filterScales.size()}, filterScales);
         auto inputScalesNode =

--- a/ngraph_creator/operations/src/Dequantize.cpp
+++ b/ngraph_creator/operations/src/Dequantize.cpp
@@ -7,15 +7,15 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Dequantize::Dequantize(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Dequantize::Dequantize(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Dequantize::createNode() {
     // Creating input nodes
     std::shared_ptr<ov::Node> input, outputNode;
     input = getInputNode(0, false);
-    const auto& inputIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
+    const auto& inputIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 0);
 
     if (checkOutputOperandType(0, (int32_t)OperandType::TENSOR_FLOAT16))
         outputNode = DequantizeNode(input, inputIndex, ov::element::f16);

--- a/ngraph_creator/operations/src/Div.cpp
+++ b/ngraph_creator/operations/src/Div.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Div::Div(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Div::Div(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Div::createNode() {
@@ -16,7 +16,7 @@ std::shared_ptr<ov::Node> Div::createNode() {
     auto input1 = getInputNode(0);
     auto input2 = getInputNode(1);
 
-    auto activationFn = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
+    auto activationFn = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
 
     auto DivNode =
         std::make_shared<ov::opset3::Divide>(input1, input2, ov::op::AutoBroadcastType::NUMPY);

--- a/ngraph_creator/operations/src/EmbeddingLookup.cpp
+++ b/ngraph_creator/operations/src/EmbeddingLookup.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-EmbeddingLookup::EmbeddingLookup(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+EmbeddingLookup::EmbeddingLookup(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 bool EmbeddingLookup::validate() {

--- a/ngraph_creator/operations/src/Equal.cpp
+++ b/ngraph_creator/operations/src/Equal.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Equal::Equal(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Equal::Equal(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Equal::createNode() {

--- a/ngraph_creator/operations/src/Exp.cpp
+++ b/ngraph_creator/operations/src/Exp.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Exp::Exp(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Exp::Exp(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Exp::createNode() {

--- a/ngraph_creator/operations/src/ExpandDims.cpp
+++ b/ngraph_creator/operations/src/ExpandDims.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-ExpandDims::ExpandDims(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+ExpandDims::ExpandDims(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 bool ExpandDims::validate() {
@@ -22,7 +22,7 @@ bool ExpandDims::validate() {
 std::shared_ptr<ov::Node> ExpandDims::createNode() {
     // Creating input nodes
     auto input = getInputNode(0);
-    auto index = sModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 1);
+    auto index = mOpModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 1);
 
     auto axes = createConstNode(ov::element::i32, {}, convertToVector(index));
 

--- a/ngraph_creator/operations/src/Floor.cpp
+++ b/ngraph_creator/operations/src/Floor.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Floor::Floor(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Floor::Floor(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Floor::createNode() {

--- a/ngraph_creator/operations/src/Gather.cpp
+++ b/ngraph_creator/operations/src/Gather.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Gather::Gather(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Gather::Gather(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Gather::createNode() {
@@ -18,7 +18,7 @@ std::shared_ptr<ov::Node> Gather::createNode() {
     gatherVals = getInputNode(0);
 
     // axis range [-n, n]
-    auto axis = sModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 1);
+    auto axis = mOpModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 1);
     auto axisNode = createConstNode(ov::element::i32, {}, convertToVector(axis));
 
     auto indices = getInputNode(2);

--- a/ngraph_creator/operations/src/Greater.cpp
+++ b/ngraph_creator/operations/src/Greater.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Greater::Greater(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Greater::Greater(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Greater::createNode() {

--- a/ngraph_creator/operations/src/GreaterEqual.cpp
+++ b/ngraph_creator/operations/src/GreaterEqual.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-GreaterEqual::GreaterEqual(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+GreaterEqual::GreaterEqual(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> GreaterEqual::createNode() {

--- a/ngraph_creator/operations/src/HardSwish.cpp
+++ b/ngraph_creator/operations/src/HardSwish.cpp
@@ -6,8 +6,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-HardSwish::HardSwish(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+HardSwish::HardSwish(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 bool HardSwish::validate() {

--- a/ngraph_creator/operations/src/HardSwish.cpp
+++ b/ngraph_creator/operations/src/HardSwish.cpp
@@ -1,0 +1,30 @@
+#include <HardSwish.hpp>
+#define LOG_TAG "HardSwish"
+
+namespace android {
+namespace hardware {
+namespace neuralnetworks {
+namespace nnhal {
+
+HardSwish::HardSwish(int operationIndex) : OperationsBase(operationIndex) {
+    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+}
+
+bool HardSwish::validate() {
+    ALOGV("%s PASSED", __func__);
+    return true;
+}
+
+std::shared_ptr<ov::Node> HardSwish::createNode() {
+    std::shared_ptr<ov::Node> outputNode, inputNode;
+    inputNode = getInputNode(0);
+
+    outputNode = std::make_shared<ov::op::v4::HSwish>(inputNode);
+
+    return outputNode;
+}
+
+}  // namespace nnhal
+}  // namespace neuralnetworks
+}  // namespace hardware
+}  // namespace android

--- a/ngraph_creator/operations/src/InstanceNormalization.cpp
+++ b/ngraph_creator/operations/src/InstanceNormalization.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-InstanceNormalization::InstanceNormalization(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+InstanceNormalization::InstanceNormalization(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 bool InstanceNormalization::validate() {
@@ -39,15 +39,15 @@ std::shared_ptr<ov::Node> InstanceNormalization::createNode() {
 
     std::shared_ptr<ov::Node> inputNode;
     bool useNchw = false;
-    const auto& inputsSize = sModelInfo->getOperationInputsSize(mNnapiOperationIndex);
+    const auto& inputsSize = mOpModelInfo->getOperationInputsSize(mNnapiOperationIndex);
     ALOGD("%s inputsSize %lu", __func__, inputsSize);
 
     // Read inputs
     inputNode = getInputNode(0);
-    auto gamma = sModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 1);
-    auto beta = sModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 2);
-    auto epsilon = sModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 3);
-    auto layout = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 4);
+    auto gamma = mOpModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 1);
+    auto beta = mOpModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 2);
+    auto epsilon = mOpModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 3);
+    auto layout = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 4);
     if (layout) useNchw = true;
 
     if (!useNchw)  // No conversion needed if useNchw set

--- a/ngraph_creator/operations/src/L2Normalization.cpp
+++ b/ngraph_creator/operations/src/L2Normalization.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-L2Normalization::L2Normalization(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+L2Normalization::L2Normalization(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 bool L2Normalization::validate() {
@@ -26,12 +26,12 @@ std::shared_ptr<ov::Node> L2Normalization::createNode() {
     std::shared_ptr<ov::Node> inputNode;
 
     int32_t inputAxes = -1;
-    const auto& inputsSize = sModelInfo->getOperationInputsSize(mNnapiOperationIndex);
+    const auto& inputsSize = mOpModelInfo->getOperationInputsSize(mNnapiOperationIndex);
     ALOGD("%s inputsSize %lu", __func__, inputsSize);
     inputNode = getInputNode(0);
     // NN-HAL 1.2 specific optional input
     if (inputsSize == 2) {
-        inputAxes = sModelInfo->ParseOperationInput<int32_t>(mNnapiOperationIndex, 1);
+        inputAxes = mOpModelInfo->ParseOperationInput<int32_t>(mNnapiOperationIndex, 1);
     }
     auto inputAxesNode = createConstNode(ov::element::i32, {1}, convertToVector(inputAxes));
     // TODO: Add support for NNAPI feature level 4, if the elements along an axis are all zeros, the

--- a/ngraph_creator/operations/src/L2Pooling2D.cpp
+++ b/ngraph_creator/operations/src/L2Pooling2D.cpp
@@ -7,14 +7,14 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-L2Pooling2D::L2Pooling2D(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+L2Pooling2D::L2Pooling2D(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> L2Pooling2D::createNode() {
     std::shared_ptr<ov::Node> inputNode;
     inputNode = getInputNode(0);
-    const auto& inputsSize = sModelInfo->getOperationInputsSize(mNnapiOperationIndex);
+    const auto& inputsSize = mOpModelInfo->getOperationInputsSize(mNnapiOperationIndex);
     bool isImplicit = false, isExplicit = false;
 
     if (inputsSize >= 10 && inputsSize <= 11) {
@@ -44,21 +44,21 @@ std::shared_ptr<ov::Node> L2Pooling2D::createNode() {
     const auto& inputDimensions = getInputOperandDimensions(0);
 
     if (isExplicit) {
-        padding_left = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 1);
-        padding_right = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
-        padding_top = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 3);
-        padding_bottom = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 4);
+        padding_left = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 1);
+        padding_right = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
+        padding_top = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 3);
+        padding_bottom = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 4);
 
-        stride_width = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 5);
-        stride_height = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 6);
+        stride_width = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 5);
+        stride_height = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 6);
 
-        filter_width = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 7);
-        filter_height = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 8);
+        filter_width = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 7);
+        filter_height = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 8);
 
-        activationFn = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 9);
+        activationFn = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 9);
 
         if (inputsSize == 11) {
-            layout = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 10);
+            layout = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 10);
         }
 
         if (layout) useNchw = true;
@@ -67,18 +67,18 @@ std::shared_ptr<ov::Node> L2Pooling2D::createNode() {
     }
 
     if (isImplicit) {
-        padding_scheme = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 1);
+        padding_scheme = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 1);
 
-        stride_width = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
-        stride_height = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 3);
+        stride_width = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
+        stride_height = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 3);
 
-        filter_width = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 4);
-        filter_height = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 5);
+        filter_width = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 4);
+        filter_height = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 5);
 
-        activationFn = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 6);
+        activationFn = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 6);
 
         if (inputsSize == 8) {
-            layout = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 7);
+            layout = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 7);
         }
 
         if (layout) useNchw = true;

--- a/ngraph_creator/operations/src/Less.cpp
+++ b/ngraph_creator/operations/src/Less.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Less::Less(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Less::Less(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Less::createNode() {

--- a/ngraph_creator/operations/src/LessEqual.cpp
+++ b/ngraph_creator/operations/src/LessEqual.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-LessEqual::LessEqual(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+LessEqual::LessEqual(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> LessEqual::createNode() {

--- a/ngraph_creator/operations/src/Log.cpp
+++ b/ngraph_creator/operations/src/Log.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Log::Log(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Log::Log(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Log::createNode() {

--- a/ngraph_creator/operations/src/LogSoftmax.cpp
+++ b/ngraph_creator/operations/src/LogSoftmax.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-LogSoftmax::LogSoftmax(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+LogSoftmax::LogSoftmax(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> LogSoftmax::createNode() {
@@ -20,15 +20,15 @@ std::shared_ptr<ov::Node> LogSoftmax::createNode() {
     std::shared_ptr<ov::Node> betaNode;
 
     if (checkInputOperandType(0, (int32_t)OperandType::TENSOR_FLOAT16)) {
-        auto beta = sModelInfo->ParseOperationInput<_Float16>(mNnapiOperationIndex, 1);
+        auto beta = mOpModelInfo->ParseOperationInput<_Float16>(mNnapiOperationIndex, 1);
         betaNode = createConstNode(ov::element::f16, {}, convertToVector(beta));
     } else {
-        auto beta = sModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 1);
+        auto beta = mOpModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 1);
         betaNode = createConstNode(ov::element::f32, {}, convertToVector(beta));
     }
     int axis = -1;
-    const auto& inputsSize = sModelInfo->getOperationInputsSize(mNnapiOperationIndex);
-    if (inputsSize == 3) axis = sModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 2);
+    const auto& inputsSize = mOpModelInfo->getOperationInputsSize(mNnapiOperationIndex);
+    if (inputsSize == 3) axis = mOpModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 2);
 
     const auto axisNode = createConstNode(ov::element::i32, {1}, convertToVector(axis));
 

--- a/ngraph_creator/operations/src/LogicalAnd.cpp
+++ b/ngraph_creator/operations/src/LogicalAnd.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-LogicalAnd::LogicalAnd(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+LogicalAnd::LogicalAnd(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> LogicalAnd::createNode() {

--- a/ngraph_creator/operations/src/LogicalNot.cpp
+++ b/ngraph_creator/operations/src/LogicalNot.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-LogicalNot::LogicalNot(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+LogicalNot::LogicalNot(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> LogicalNot::createNode() {

--- a/ngraph_creator/operations/src/LogicalOr.cpp
+++ b/ngraph_creator/operations/src/LogicalOr.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-LogicalOr::LogicalOr(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+LogicalOr::LogicalOr(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> LogicalOr::createNode() {

--- a/ngraph_creator/operations/src/Logistic.cpp
+++ b/ngraph_creator/operations/src/Logistic.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Logistic::Logistic(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Logistic::Logistic(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Logistic::createNode() {

--- a/ngraph_creator/operations/src/MaxPool2d.cpp
+++ b/ngraph_creator/operations/src/MaxPool2d.cpp
@@ -7,14 +7,14 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-MaxPool2d::MaxPool2d(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+MaxPool2d::MaxPool2d(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> MaxPool2d::createNode() {
     std::shared_ptr<ov::Node> inputNode;
     inputNode = getInputNode(0);
-    const auto& inputsSize = sModelInfo->getOperationInputsSize(mNnapiOperationIndex);
+    const auto& inputsSize = mOpModelInfo->getOperationInputsSize(mNnapiOperationIndex);
     ALOGD("%s inputsSize %lu", __func__, inputsSize);
 
     bool isImplicit = false, isExplicit = false;
@@ -46,21 +46,21 @@ std::shared_ptr<ov::Node> MaxPool2d::createNode() {
     const auto& inputDimensions = getInputOperandDimensions(0);
 
     if (isExplicit) {
-        padding_left = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 1);
-        padding_right = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
-        padding_top = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 3);
-        padding_bottom = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 4);
+        padding_left = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 1);
+        padding_right = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
+        padding_top = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 3);
+        padding_bottom = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 4);
 
-        stride_width = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 5);
-        stride_height = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 6);
+        stride_width = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 5);
+        stride_height = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 6);
 
-        filter_width = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 7);
-        filter_height = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 8);
+        filter_width = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 7);
+        filter_height = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 8);
 
-        activationFn = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 9);
+        activationFn = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 9);
 
         if (inputsSize == 11) {
-            layout = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 10);
+            layout = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 10);
         }
 
         if (layout) useNchw = true;
@@ -69,18 +69,18 @@ std::shared_ptr<ov::Node> MaxPool2d::createNode() {
     }
 
     if (isImplicit) {
-        padding_scheme = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 1);
+        padding_scheme = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 1);
 
-        stride_width = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
-        stride_height = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 3);
+        stride_width = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
+        stride_height = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 3);
 
-        filter_width = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 4);
-        filter_height = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 5);
+        filter_width = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 4);
+        filter_height = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 5);
 
-        activationFn = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 6);
+        activationFn = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 6);
 
         if (inputsSize == 8) {
-            layout = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 7);
+            layout = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 7);
         }
 
         if (layout) useNchw = true;

--- a/ngraph_creator/operations/src/Maximum.cpp
+++ b/ngraph_creator/operations/src/Maximum.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Maximum::Maximum(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Maximum::Maximum(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Maximum::createNode() {

--- a/ngraph_creator/operations/src/Mean.cpp
+++ b/ngraph_creator/operations/src/Mean.cpp
@@ -7,15 +7,15 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Mean::Mean(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Mean::Mean(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 bool Mean::validate() {
     // TODO: Add Support for all_tensors_as_inputs
-    const auto& axesOperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+    const auto& axesOperandIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 1);
 
-    if (!sModelInfo->isOperandLifeTimeConst(axesOperandIndex)) {
+    if (!mOpModelInfo->isOperandLifeTimeConst(axesOperandIndex)) {
         ALOGE("%s Only Constant dimensions supported now", __func__);
         return false;
     }
@@ -30,7 +30,7 @@ std::shared_ptr<ov::Node> Mean::createNode() {
     input = getInputNode(0);
 
     auto reduction_axes = getInputNode(1);
-    auto reduce_dims = sModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 2);
+    auto reduce_dims = mOpModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 2);
     bool keep_dims = (reduce_dims > 0) ? true : false;
 
     std::shared_ptr<ov::Node> outputNode;

--- a/ngraph_creator/operations/src/Minimum.cpp
+++ b/ngraph_creator/operations/src/Minimum.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Minimum::Minimum(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Minimum::Minimum(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Minimum::createNode() {

--- a/ngraph_creator/operations/src/Mul.cpp
+++ b/ngraph_creator/operations/src/Mul.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Mul::Mul(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Mul::Mul(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Mul::createNode() {
@@ -18,7 +18,7 @@ std::shared_ptr<ov::Node> Mul::createNode() {
     input1 = getInputNode(0);
     input2 = getInputNode(1);
 
-    auto activationFn = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
+    auto activationFn = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
 
     auto mulNode =
         std::make_shared<ov::opset3::Multiply>(input1, input2, ov::op::AutoBroadcastType::NUMPY);

--- a/ngraph_creator/operations/src/Neg.cpp
+++ b/ngraph_creator/operations/src/Neg.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Neg::Neg(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Neg::Neg(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Neg::createNode() {

--- a/ngraph_creator/operations/src/NotEqual.cpp
+++ b/ngraph_creator/operations/src/NotEqual.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-NotEqual::NotEqual(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+NotEqual::NotEqual(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> NotEqual::createNode() {

--- a/ngraph_creator/operations/src/OperationsBase.cpp
+++ b/ngraph_creator/operations/src/OperationsBase.cpp
@@ -7,9 +7,6 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-IntelDeviceType OperationsBase::sPluginType;
-std::shared_ptr<NnapiModelInfo> OperationsBase::sModelInfo;
-
 std::shared_ptr<ov::Node> OperationsBase::transpose(ConversionType type,
                                                     ov::Output<ov::Node> input) {
     ov::AxisVector order;
@@ -62,13 +59,13 @@ std::shared_ptr<ov::Node> OperationsBase::transpose(ConversionType type,
     return std::make_shared<ov::opset3::Transpose>(input, order_node);
 }
 
-// override createNodeForPlugin in case sPluginType specific implementation is required
+// override createNodeForPlugin in case mPluginType specific implementation is required
 std::shared_ptr<ov::Node> OperationsBase::createNodeForPlugin() { return createNode(); }
 
 // override connectOperationToGraph in case Operation has multiple outputs
 void OperationsBase::connectOperationToGraph() {
     auto outputNode = createNodeForPlugin();
-    const auto op = sModelInfo->getOperand(mDefaultOutputIndex);
+    const auto op = mOpModelInfo->getOperand(mDefaultOutputIndex);
     if (op.type == OperandType::TENSOR_QUANT8_ASYMM) {
         outputNode = QuantizeNode(outputNode, mDefaultOutputIndex, ov::element::u8);
     }
@@ -96,8 +93,10 @@ void OperationsBase::addResultNode(size_t index, std::shared_ptr<ov::Node> resul
     mNgraphNodes->setResultNode(index, resultNode);
 }
 
-OperationsBase::OperationsBase(int operationIndex) : mNnapiOperationIndex(operationIndex) {
+OperationsBase::OperationsBase(int operationIndex, GraphMetadata graphMetadata) : mNnapiOperationIndex(operationIndex) {
     mDefaultOutputIndex = 0;
+    mOpModelInfo = graphMetadata.modelInfo;
+    mPluginType = graphMetadata.pluginType;
 }
 
 void OperationsBase::setNgraphNodes(std::shared_ptr<NgraphNodes> nodes) { mNgraphNodes = nodes; }
@@ -111,7 +110,7 @@ bool OperationsBase::validateForPlugin() {
 
 bool OperationsBase::checkOperandType(uint32_t operandIndex, const int32_t expectedOperandType,
                                       const std::string& strLogInfo) {
-    const auto operandType = (int32_t)sModelInfo->getOperandType(operandIndex);
+    const auto operandType = (int32_t)mOpModelInfo->getOperandType(operandIndex);
     if (operandType != expectedOperandType) {
         ALOGV("OperationIndex %d %s Index %d type %d invalid", mNnapiOperationIndex,
               strLogInfo.c_str(), operandIndex, operandType);
@@ -122,16 +121,16 @@ bool OperationsBase::checkOperandType(uint32_t operandIndex, const int32_t expec
     return true;
 }
 bool OperationsBase::checkOutputOperandType(uint32_t index, const int32_t expectedOperandType) {
-    const auto& operandIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, index);
+    const auto& operandIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, index);
     return checkOperandType(operandIndex, expectedOperandType, "Output");
 }
 bool OperationsBase::checkInputOperandType(uint32_t index, const int32_t expectedOperandType) {
-    const auto& operandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, index);
+    const auto& operandIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, index);
     return checkOperandType(operandIndex, expectedOperandType, "Input");
 }
 const vec<uint32_t> OperationsBase::getInputOperandDimensions(uint32_t inputIndex) {
-    const auto& operandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, inputIndex);
-    const auto& operand = sModelInfo->getOperand(operandIndex);
+    const auto& operandIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, inputIndex);
+    const auto& operand = mOpModelInfo->getOperand(operandIndex);
     return operand.dimensions;
 }
 
@@ -153,8 +152,8 @@ std::shared_ptr<ov::Node> OperationsBase::QuantizeNode(std::shared_ptr<ov::Node>
     auto floatElementType = ov::element::f32;
     auto intElementType = ov::element::i32;
 
-    float inputScale = sModelInfo->getOperandScale(index);
-    int inputZeroPoint = sModelInfo->getOperandZeroPoint(index);
+    float inputScale = mOpModelInfo->getOperandScale(index);
+    int inputZeroPoint = mOpModelInfo->getOperandZeroPoint(index);
 
     auto scale = createConstNode(floatElementType, {}, convertToVector(inputScale));
     auto zeroPoint = createConstNode(intElementType, {}, convertToVector(inputZeroPoint));
@@ -168,7 +167,7 @@ std::shared_ptr<ov::Node> OperationsBase::QuantizeNode(std::shared_ptr<ov::Node>
     auto convertRound = std::make_shared<ov::opset3::Convert>(round, ov::element::i32);
     auto sum = std::make_shared<ov::opset3::Add>(convertRound, zeroPoint);
     std::shared_ptr<ov::Node> data;
-    const auto operand = sModelInfo->getOperand(index);
+    const auto operand = mOpModelInfo->getOperand(index);
 
     if (operand.type == OperandType::TENSOR_QUANT8_ASYMM) {
         data = std::make_shared<ov::opset3::Clamp>(sum, 0, 255);
@@ -194,7 +193,7 @@ std::shared_ptr<ov::Node> OperationsBase::QuantizeNode(std::shared_ptr<ov::Node>
 std::shared_ptr<ov::Node> OperationsBase::DequantizeNode(std::shared_ptr<ov::Node> input,
                                                          uint32_t index,
                                                          ov::element::Type dequantizeType) {
-    const auto operand = sModelInfo->getOperand(index);
+    const auto operand = mOpModelInfo->getOperand(index);
     std::shared_ptr<ov::Node> outputNode;
 
     if (input->get_element_type() != ov::element::f32)
@@ -212,9 +211,9 @@ std::shared_ptr<ov::Node> OperationsBase::DequantizeNode(std::shared_ptr<ov::Nod
         outputNode = std::make_shared<ov::opset3::Multiply>(input, scaleNode);
     } else {
         auto scaleNode = createConstNode(ov::element::f32, {},
-                                         convertToVector(sModelInfo->getOperandScale(index)));
+                                         convertToVector(mOpModelInfo->getOperandScale(index)));
         auto zeroPointNode = createConstNode(
-            ov::element::f32, {}, convertToVector(sModelInfo->getOperandZeroPoint(index)));
+            ov::element::f32, {}, convertToVector(mOpModelInfo->getOperandZeroPoint(index)));
 
         if (operand.type == OperandType::TENSOR_QUANT8_ASYMM ||
             operand.type == OperandType::TENSOR_QUANT16_ASYMM ||

--- a/ngraph_creator/operations/src/PRelu.cpp
+++ b/ngraph_creator/operations/src/PRelu.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-PRelu::PRelu(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+PRelu::PRelu(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 bool PRelu::validate() {

--- a/ngraph_creator/operations/src/Pad.cpp
+++ b/ngraph_creator/operations/src/Pad.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Pad::Pad(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Pad::Pad(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 bool Pad::validate() {
@@ -20,9 +20,9 @@ bool Pad::validate() {
     if (inputRank < 2) return false;
 
     // TODO: Add Support for all_tensors_as_inputs
-    const auto& padOperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+    const auto& padOperandIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 1);
 
-    if (!sModelInfo->isOperandLifeTimeConst(padOperandIndex)) {
+    if (!mOpModelInfo->isOperandLifeTimeConst(padOperandIndex)) {
         ALOGE("%s Only Constant dimensions supported now", __func__);
         return false;
     }
@@ -34,9 +34,9 @@ std::shared_ptr<ov::Node> Pad::createNode() {
     // Creating input nodes
     auto inputNode = getInputNode(0);
 
-    const auto& paddingsOperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+    const auto& paddingsOperandIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 1);
     // Fetch the 2D paddings as a 1D vector, and then split it into 2
-    auto paddings_2d = sModelInfo->GetConstVecOperand<int32_t>(paddingsOperandIndex);
+    auto paddings_2d = mOpModelInfo->GetConstVecOperand<int32_t>(paddingsOperandIndex);
     auto half_size = paddings_2d.size() / 2;
     std::vector<int32_t> paddings_0(half_size);
     std::vector<int32_t> paddings_1(half_size);

--- a/ngraph_creator/operations/src/PadV2.cpp
+++ b/ngraph_creator/operations/src/PadV2.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-PadV2::PadV2(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+PadV2::PadV2(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 bool PadV2::validate() {
@@ -20,9 +20,9 @@ bool PadV2::validate() {
     if (inputRank < 2) return false;
 
     // TODO: Add Support for all_tensors_as_inputs
-    const auto& padOperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+    const auto& padOperandIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 1);
 
-    if (!sModelInfo->isOperandLifeTimeConst(padOperandIndex)) {
+    if (!mOpModelInfo->isOperandLifeTimeConst(padOperandIndex)) {
         ALOGE("%s Only Constant dimensions supported now", __func__);
         return false;
     }
@@ -34,17 +34,17 @@ std::shared_ptr<ov::Node> PadV2::createNode() {
     // Creating input nodes
     auto inputNode = getInputNode(0);
     std::shared_ptr<ov::Node> pad_value;
-    auto inputIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
+    auto inputIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 0);
 
     if (checkInputOperandType(0, (int32_t)OperandType::TENSOR_FLOAT32)) {
-        auto pad_scalar_value = sModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 2);
+        auto pad_scalar_value = mOpModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 2);
         pad_value = createConstNode(ov::element::f32, {}, convertToVector(pad_scalar_value));
     } else if (checkInputOperandType(0, (int32_t)OperandType::TENSOR_FLOAT16)) {
-        auto pad_scalar_value = sModelInfo->ParseOperationInput<_Float16>(mNnapiOperationIndex, 2);
+        auto pad_scalar_value = mOpModelInfo->ParseOperationInput<_Float16>(mNnapiOperationIndex, 2);
         pad_value = createConstNode(ov::element::f16, {}, convertToVector(pad_scalar_value));
     } else if (checkInputOperandType(0, (int32_t)OperandType::TENSOR_QUANT8_ASYMM) ||
                checkInputOperandType(0, (int32_t)OperandType::TENSOR_QUANT8_ASYMM_SIGNED)) {
-        auto pad_scalar_value = sModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 2);
+        auto pad_scalar_value = mOpModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 2);
         pad_value = createConstNode(ov::element::i32, {}, convertToVector(pad_scalar_value));
 
         // scale and zeropoint of pad value has to be same as in inputNode. so inputIndex is passed
@@ -52,9 +52,9 @@ std::shared_ptr<ov::Node> PadV2::createNode() {
         pad_value = DequantizeNode(pad_value, inputIndex, ov::element::f32);
     }
 
-    const auto& paddingsOperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+    const auto& paddingsOperandIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 1);
     // Fetch the 2D paddings as a 1D vector, and then split it into 2
-    auto paddings_2d = sModelInfo->GetConstVecOperand<int32_t>(paddingsOperandIndex);
+    auto paddings_2d = mOpModelInfo->GetConstVecOperand<int32_t>(paddingsOperandIndex);
     auto half_size = paddings_2d.size() / 2;
     std::vector<int32_t> paddings_0(half_size);
     std::vector<int32_t> paddings_1(half_size);

--- a/ngraph_creator/operations/src/Pow.cpp
+++ b/ngraph_creator/operations/src/Pow.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Pow::Pow(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Pow::Pow(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Pow::createNode() {

--- a/ngraph_creator/operations/src/Quantize.cpp
+++ b/ngraph_creator/operations/src/Quantize.cpp
@@ -16,11 +16,21 @@ void Quantize::connectOperationToGraph() { createNode(); }
 std::shared_ptr<ov::Node> Quantize::createNode() {
     // Creating input nodes
     auto input = getInputNode(0);
+    ov::element::Type elementType;
     const auto& outputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
-    auto outputNode = QuantizeNode(input, outputIndex, ov::element::u8);
+    if (checkOutputOperandType(0, (int32_t)OperandType::TENSOR_QUANT8_ASYMM)) {
+        elementType = ov::element::u8;
+    } else if (checkOutputOperandType(0, (int32_t)OperandType::TENSOR_QUANT8_ASYMM_SIGNED)) {
+        elementType = ov::element::i8;
+    } else {
+        ALOGE("Invalid Output Operand Type %d",sModelInfo->getOperandType(outputIndex));
+    }
+    auto outputNode = QuantizeNode(input, outputIndex, elementType);
 
-    mNgraphNodes->setOutputAtOperandIndex(outputIndex, outputNode);
-
+    if (outputNode != nullptr)
+    {
+        mNgraphNodes->setOutputAtOperandIndex(outputIndex, outputNode);
+    }
     return nullptr;
 }
 

--- a/ngraph_creator/operations/src/Quantize.cpp
+++ b/ngraph_creator/operations/src/Quantize.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Quantize::Quantize(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Quantize::Quantize(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 void Quantize::connectOperationToGraph() { createNode(); }
@@ -17,13 +17,13 @@ std::shared_ptr<ov::Node> Quantize::createNode() {
     // Creating input nodes
     auto input = getInputNode(0);
     ov::element::Type elementType;
-    const auto& outputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+    const auto& outputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
     if (checkOutputOperandType(0, (int32_t)OperandType::TENSOR_QUANT8_ASYMM)) {
         elementType = ov::element::u8;
     } else if (checkOutputOperandType(0, (int32_t)OperandType::TENSOR_QUANT8_ASYMM_SIGNED)) {
         elementType = ov::element::i8;
     } else {
-        ALOGE("Invalid Output Operand Type %d",sModelInfo->getOperandType(outputIndex));
+        ALOGE("Invalid Output Operand Type %d",mOpModelInfo->getOperandType(outputIndex));
     }
     auto outputNode = QuantizeNode(input, outputIndex, elementType);
 

--- a/ngraph_creator/operations/src/RNN.cpp
+++ b/ngraph_creator/operations/src/RNN.cpp
@@ -9,8 +9,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-RNN::RNN(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+RNN::RNN(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 void RNN::connectOperationToGraph() { createNode(); }
@@ -25,7 +25,7 @@ std::shared_ptr<ov::Node> RNN::createNode() {
     bias = getInputNode(3);
     initial_hidden_state = getInputNode(4);
 
-    auto activationFn = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 5);
+    auto activationFn = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 5);
 
     // inputs * input_weights
     auto input_W = std::make_shared<ov::opset3::MatMul>(input, W, false, true);
@@ -39,7 +39,7 @@ std::shared_ptr<ov::Node> RNN::createNode() {
     auto outputNode = applyActivation(i_t, activationFn);
 
     for (int i = 0; i < 2; i++) {
-        auto outputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, i);
+        auto outputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, i);
         std::shared_ptr<ov::Node> outNode;
         if (i == 1) {
             outNode = outputNode;

--- a/ngraph_creator/operations/src/ROIAlign.cpp
+++ b/ngraph_creator/operations/src/ROIAlign.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-ROIAlign::ROIAlign(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+ROIAlign::ROIAlign(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 bool ROIAlign::validate() {
@@ -36,8 +36,8 @@ bool ROIAlign::validate() {
 
     // TODO: support for different height_ratio and width_ratio
     // values
-    auto height_ratio = sModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 5);
-    auto width_ratio = sModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 6);
+    auto height_ratio = mOpModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 5);
+    auto width_ratio = mOpModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 6);
     if (height_ratio != width_ratio) {
         ALOGE(
             "%s: Ratio of Height and Ratio of Width from orginal image to feature map must be same "
@@ -59,19 +59,19 @@ std::shared_ptr<ov::Node> ROIAlign::createNode() {
     auto feat_maps = getInputNode(0);      // 4D tensor
     auto rois = getInputNode(1);           // 2D tensor
     auto batch_indices = getInputNode(2);  // 1D tensor
-    auto output_height = sModelInfo->ParseOperationInput<int32_t>(
+    auto output_height = mOpModelInfo->ParseOperationInput<int32_t>(
         mNnapiOperationIndex, 3);  // height of the output tensor
-    auto output_width = sModelInfo->ParseOperationInput<int32_t>(mNnapiOperationIndex,
+    auto output_width = mOpModelInfo->ParseOperationInput<int32_t>(mNnapiOperationIndex,
                                                                  4);  // width of the output tensor
-    auto height_ratio = sModelInfo->ParseOperationInput<float>(
+    auto height_ratio = mOpModelInfo->ParseOperationInput<float>(
         mNnapiOperationIndex,
         5);  // ratio from the height of original image to the height of feature map.
-    // auto width_ratio = sModelInfo->ParseOperationInput<float>(
+    // auto width_ratio = mOpModelInfo->ParseOperationInput<float>(
     //     mNnapiOperationIndex,
     //     6);  // ratio from the width of original image to the height of feature map.
-    auto sampling_pts_h = sModelInfo->ParseOperationInput<int32_t>(mNnapiOperationIndex, 7);
-    // auto sampling_pts_w = sModelInfo->ParseOperationInput<int32_t>(mNnapiOperationIndex, 8);
-    auto layout = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 9);
+    auto sampling_pts_h = mOpModelInfo->ParseOperationInput<int32_t>(mNnapiOperationIndex, 7);
+    // auto sampling_pts_w = mOpModelInfo->ParseOperationInput<int32_t>(mNnapiOperationIndex, 8);
+    auto layout = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 9);
 
     if (layout) useNchw = true;
 

--- a/ngraph_creator/operations/src/RSQRT.cpp
+++ b/ngraph_creator/operations/src/RSQRT.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-RSQRT::RSQRT(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+RSQRT::RSQRT(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> RSQRT::createNode() {

--- a/ngraph_creator/operations/src/ReduceAll.cpp
+++ b/ngraph_creator/operations/src/ReduceAll.cpp
@@ -7,15 +7,15 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-ReduceAll::ReduceAll(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+ReduceAll::ReduceAll(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> ReduceAll::createNode() {
     // Creating input nodes
     auto input = getInputNode(0);
     auto reduction_axes = getInputNode(1);
-    auto keep_dims = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
+    auto keep_dims = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
 
     auto outputNode =
         std::make_shared<ov::opset3::ReduceLogicalAnd>(input, reduction_axes, keep_dims);

--- a/ngraph_creator/operations/src/ReduceAny.cpp
+++ b/ngraph_creator/operations/src/ReduceAny.cpp
@@ -7,15 +7,15 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-ReduceAny::ReduceAny(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+ReduceAny::ReduceAny(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> ReduceAny::createNode() {
     // Creating input nodes
     auto input = getInputNode(0);
     auto reduction_axes = getInputNode(1);
-    auto keep_dims = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
+    auto keep_dims = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
 
     auto outputNode =
         std::make_shared<ov::opset3::ReduceLogicalOr>(input, reduction_axes, keep_dims);

--- a/ngraph_creator/operations/src/ReduceMax.cpp
+++ b/ngraph_creator/operations/src/ReduceMax.cpp
@@ -7,15 +7,15 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-ReduceMax::ReduceMax(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+ReduceMax::ReduceMax(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> ReduceMax::createNode() {
     // Creating input nodes
     auto input = getInputNode(0);
     auto reduction_axes = getInputNode(1);
-    auto keep_dims = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
+    auto keep_dims = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
 
     std::shared_ptr<ov::Node> outputNode;
     outputNode = std::make_shared<ov::opset3::ReduceMax>(input, reduction_axes, keep_dims);

--- a/ngraph_creator/operations/src/ReduceMin.cpp
+++ b/ngraph_creator/operations/src/ReduceMin.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-ReduceMin::ReduceMin(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+ReduceMin::ReduceMin(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> ReduceMin::createNode() {
@@ -18,7 +18,7 @@ std::shared_ptr<ov::Node> ReduceMin::createNode() {
     input = getInputNode(0);
 
     auto reduction_axes = getInputNode(1);
-    auto keep_dims = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
+    auto keep_dims = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
 
     std::shared_ptr<ov::Node> outputNode;
     outputNode = std::make_shared<ov::opset3::ReduceMin>(input, reduction_axes, keep_dims);

--- a/ngraph_creator/operations/src/ReduceProd.cpp
+++ b/ngraph_creator/operations/src/ReduceProd.cpp
@@ -7,15 +7,15 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-ReduceProd::ReduceProd(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+ReduceProd::ReduceProd(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> ReduceProd::createNode() {
     // Creating input nodes
     auto input = getInputNode(0);
     auto reduction_axes = getInputNode(1);
-    auto keep_dims = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
+    auto keep_dims = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
 
     auto outputNode = std::make_shared<ov::opset3::ReduceProd>(input, reduction_axes, keep_dims);
 

--- a/ngraph_creator/operations/src/ReduceSum.cpp
+++ b/ngraph_creator/operations/src/ReduceSum.cpp
@@ -7,15 +7,15 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-ReduceSum::ReduceSum(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+ReduceSum::ReduceSum(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> ReduceSum::createNode() {
     // Creating input nodes
     auto input = getInputNode(0);
     auto reduction_axes = getInputNode(1);
-    auto keep_dims = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
+    auto keep_dims = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
 
     auto outputNode = std::make_shared<ov::opset3::ReduceSum>(input, reduction_axes, keep_dims);
 

--- a/ngraph_creator/operations/src/Relu.cpp
+++ b/ngraph_creator/operations/src/Relu.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Relu::Relu(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Relu::Relu(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Relu::createNode() {

--- a/ngraph_creator/operations/src/Relu1.cpp
+++ b/ngraph_creator/operations/src/Relu1.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Relu1::Relu1(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Relu1::Relu1(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Relu1::createNode() {

--- a/ngraph_creator/operations/src/Relu6.cpp
+++ b/ngraph_creator/operations/src/Relu6.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Relu6::Relu6(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Relu6::Relu6(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Relu6::createNode() {

--- a/ngraph_creator/operations/src/Reshape.cpp
+++ b/ngraph_creator/operations/src/Reshape.cpp
@@ -7,13 +7,13 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Reshape::Reshape(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Reshape::Reshape(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 bool Reshape::validate() {
-    const auto& dimsOperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
-    if (!sModelInfo->isOperandLifeTimeConst(dimsOperandIndex) || !isValidInputTensor(1)) {
+    const auto& dimsOperandIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+    if (!mOpModelInfo->isOperandLifeTimeConst(dimsOperandIndex) || !isValidInputTensor(1)) {
         // TODO: Support CPU_reshape_all_tensors_as_inputs
         ALOGE("%s Only Constant non-zero dimensions supported now", __func__);
         return false;
@@ -23,8 +23,8 @@ bool Reshape::validate() {
 }
 
 std::shared_ptr<ov::Node> Reshape::createNode() {
-    const auto& dimsOperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
-    auto outDims = sModelInfo->GetConstVecOperand<int32_t>(dimsOperandIndex);
+    const auto& dimsOperandIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+    auto outDims = mOpModelInfo->GetConstVecOperand<int32_t>(dimsOperandIndex);
     VLOGDIMS(L3, outDims, "Reshape::createNode dims");
     std::shared_ptr<ov::Node> inputOp;
     inputOp = getInputNode(0);

--- a/ngraph_creator/operations/src/ResizeNearestNeighbor.cpp
+++ b/ngraph_creator/operations/src/ResizeNearestNeighbor.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-ResizeNearestNeighbor::ResizeNearestNeighbor(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+ResizeNearestNeighbor::ResizeNearestNeighbor(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 bool ResizeNearestNeighbor::validate() {
@@ -22,7 +22,7 @@ bool ResizeNearestNeighbor::validate() {
 }
 
 std::shared_ptr<ov::Node> ResizeNearestNeighbor::createNode() {
-    const auto& inputsSize = sModelInfo->getOperationInputsSize(mNnapiOperationIndex);
+    const auto& inputsSize = mOpModelInfo->getOperationInputsSize(mNnapiOperationIndex);
 
     std::shared_ptr<ov::Node> outputNode;
     int32_t input_width = 0, input_height = 0;
@@ -39,13 +39,13 @@ std::shared_ptr<ov::Node> ResizeNearestNeighbor::createNode() {
     inputNode = getInputNode(0);
     switch (inputsSize) {
         case 6:
-            half_pixel = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 5);
+            half_pixel = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 5);
             __attribute__((fallthrough));
         case 5:
-            align_corners = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 4);
+            align_corners = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 4);
             __attribute__((fallthrough));
         case 4:
-            layout = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 3);
+            layout = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 3);
             __attribute__((fallthrough));
         default:
             break;
@@ -60,8 +60,8 @@ std::shared_ptr<ov::Node> ResizeNearestNeighbor::createNode() {
         input_height = inputDimensions[1];
     }
 
-    const auto& inputIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
-    const auto inputOp = sModelInfo->getOperand(inputIndex);
+    const auto& inputIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 0);
+    const auto inputOp = mOpModelInfo->getOperand(inputIndex);
     if (!useNchw) {
         inputNode = transpose(NHWC_NCHW, inputNode);
     }
@@ -73,8 +73,8 @@ std::shared_ptr<ov::Node> ResizeNearestNeighbor::createNode() {
     if (checkInputOperandType(1, (int32_t)OperandType::FLOAT32)) {
         // In tensorflow lite, resizing by size is supported. Scaling factors are
         // calculated based on output shape.
-        width_scale = sModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 1);
-        height_scale = sModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 2);
+        width_scale = mOpModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 1);
+        height_scale = mOpModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 2);
         out_width = (int)(input_width * width_scale);
         out_height = (int)(input_height * height_scale);
         // Recalculating scaling factors here because of typecasting output shape to
@@ -82,15 +82,15 @@ std::shared_ptr<ov::Node> ResizeNearestNeighbor::createNode() {
         width_scale = (float)out_width / (float)input_width;
         height_scale = (float)out_height / (float)input_height;
     } else if (checkInputOperandType(1, (int32_t)OperandType::FLOAT16)) {
-        width_scale = sModelInfo->ParseOperationInput<_Float16>(mNnapiOperationIndex, 1);
-        height_scale = sModelInfo->ParseOperationInput<_Float16>(mNnapiOperationIndex, 2);
+        width_scale = mOpModelInfo->ParseOperationInput<_Float16>(mNnapiOperationIndex, 1);
+        height_scale = mOpModelInfo->ParseOperationInput<_Float16>(mNnapiOperationIndex, 2);
         out_width = (int)(input_width * width_scale);
         out_height = (int)(input_height * height_scale);
         width_scale = (float)out_width / (float)input_width;
         height_scale = (float)out_height / (float)input_height;
     } else if (checkInputOperandType(1, (int32_t)OperandType::INT32)) {
-        out_width = sModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 1);
-        out_height = sModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 2);
+        out_width = mOpModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 1);
+        out_height = mOpModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 2);
         width_scale = (float)out_width / (float)input_width;
         height_scale = (float)out_height / (float)input_height;
     }

--- a/ngraph_creator/operations/src/ResizeNearestNeighbor.cpp
+++ b/ngraph_creator/operations/src/ResizeNearestNeighbor.cpp
@@ -12,18 +12,6 @@ ResizeNearestNeighbor::ResizeNearestNeighbor(int operationIndex) : OperationsBas
 }
 
 bool ResizeNearestNeighbor::validate() {
-    // TODO Add FLOAT16 check when VPUX plugin is supported
-    if (!checkOutputOperandType(0, (int32_t)OperandType::TENSOR_FLOAT32) &&
-        !checkOutputOperandType(0, (int32_t)OperandType::TENSOR_QUANT8_ASYMM)) {
-        ALOGE("%s check for output types failed", __func__);
-        return false;
-    }
-
-    if (!checkInputOperandType(0, (int32_t)OperandType::TENSOR_FLOAT32) &&
-        !checkInputOperandType(0, (int32_t)OperandType::TENSOR_QUANT8_ASYMM)) {
-        return false;
-    }
-
     const auto& inputDimensionsSize = getInputOperandDimensions(0).size();
     if (inputDimensionsSize != 4) {
         ALOGE("%s Invalid dimensions size for input(%lu)", __func__, inputDimensionsSize);
@@ -72,13 +60,19 @@ std::shared_ptr<ov::Node> ResizeNearestNeighbor::createNode() {
         input_height = inputDimensions[1];
     }
 
-    if (!useNchw) inputNode = transpose(NHWC_NCHW, inputNode);
-    // FLOAT16 type check added for future when VPUX plugin support is added
-    if (checkInputOperandType(1, (int32_t)OperandType::FLOAT32) ||
-        checkInputOperandType(1, (int32_t)OperandType::FLOAT16)) {
+    const auto& inputIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
+    const auto inputOp = sModelInfo->getOperand(inputIndex);
+    if (!useNchw) {
+        inputNode = transpose(NHWC_NCHW, inputNode);
+    }
+    // mode is passed as "nearest" for Nearest Neighbor interpolation
+    attrs.mode = ov::op::v4::Interpolate::InterpolateMode::nearest;
+    attrs.nearest_mode = ov::op::v4::Interpolate::NearestMode::floor;
+    attrs.shape_calculation_mode = ov::op::v4::Interpolate::ShapeCalcMode::sizes;
+
+    if (checkInputOperandType(1, (int32_t)OperandType::FLOAT32)) {
         // In tensorflow lite, resizing by size is supported. Scaling factors are
         // calculated based on output shape.
-        attrs.shape_calculation_mode = ov::op::v4::Interpolate::ShapeCalcMode::sizes;
         width_scale = sModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 1);
         height_scale = sModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 2);
         out_width = (int)(input_width * width_scale);
@@ -87,8 +81,14 @@ std::shared_ptr<ov::Node> ResizeNearestNeighbor::createNode() {
         // integer
         width_scale = (float)out_width / (float)input_width;
         height_scale = (float)out_height / (float)input_height;
+    } else if (checkInputOperandType(1, (int32_t)OperandType::FLOAT16)) {
+        width_scale = sModelInfo->ParseOperationInput<_Float16>(mNnapiOperationIndex, 1);
+        height_scale = sModelInfo->ParseOperationInput<_Float16>(mNnapiOperationIndex, 2);
+        out_width = (int)(input_width * width_scale);
+        out_height = (int)(input_height * height_scale);
+        width_scale = (float)out_width / (float)input_width;
+        height_scale = (float)out_height / (float)input_height;
     } else if (checkInputOperandType(1, (int32_t)OperandType::INT32)) {
-        attrs.shape_calculation_mode = ov::op::v4::Interpolate::ShapeCalcMode::sizes;
         out_width = sModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 1);
         out_height = sModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 2);
         width_scale = (float)out_width / (float)input_width;
@@ -98,19 +98,17 @@ std::shared_ptr<ov::Node> ResizeNearestNeighbor::createNode() {
     if (align_corners == true) {
         attrs.coordinate_transformation_mode =
             ov::op::v4::Interpolate::CoordinateTransformMode::align_corners;
+        attrs.nearest_mode = ov::op::v4::Interpolate::NearestMode::round_prefer_ceil;
     } else if (half_pixel == true) {
         attrs.coordinate_transformation_mode =
             ov::op::v4::Interpolate::CoordinateTransformMode::half_pixel;
+            attrs.nearest_mode = ov::op::v4::Interpolate::NearestMode::round_prefer_ceil;
     } else {
         // If none of the align_corners and half_pixel are true, transformation
         // mode is set to asymmetric
         attrs.coordinate_transformation_mode =
             ov::op::v4::Interpolate::CoordinateTransformMode::asymmetric;
     }
-
-    // mode is passed as "nearest" for Nearest Neighbor interpolation
-    attrs.mode = ov::op::v4::Interpolate::InterpolateMode::nearest;
-    attrs.nearest_mode = ov::op::v4::Interpolate::NearestMode::floor;
 
     std::vector<int32_t> output_shape = {out_height, out_width};
     auto outputShapeNode = createConstNode(ov::element::i32, {2}, output_shape);

--- a/ngraph_creator/operations/src/SQRT.cpp
+++ b/ngraph_creator/operations/src/SQRT.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-SQRT::SQRT(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+SQRT::SQRT(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> SQRT::createNode() {

--- a/ngraph_creator/operations/src/Select.cpp
+++ b/ngraph_creator/operations/src/Select.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Select::Select(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Select::Select(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Select::createNode() {

--- a/ngraph_creator/operations/src/Sin.cpp
+++ b/ngraph_creator/operations/src/Sin.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Sin::Sin(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Sin::Sin(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Sin::createNode() {

--- a/ngraph_creator/operations/src/Softmax.cpp
+++ b/ngraph_creator/operations/src/Softmax.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Softmax::Softmax(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Softmax::Softmax(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Softmax::createNode() {
@@ -20,15 +20,15 @@ std::shared_ptr<ov::Node> Softmax::createNode() {
     std::shared_ptr<ov::Node> betaNode;
 
     if (checkInputOperandType(0, (int32_t)OperandType::TENSOR_FLOAT16)) {
-        auto beta = sModelInfo->ParseOperationInput<_Float16>(mNnapiOperationIndex, 1);
+        auto beta = mOpModelInfo->ParseOperationInput<_Float16>(mNnapiOperationIndex, 1);
         betaNode = createConstNode(ov::element::f16, {1}, convertToVector(beta));
     } else {
-        auto beta = sModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 1);
+        auto beta = mOpModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 1);
         betaNode = createConstNode(ov::element::f32, {1}, convertToVector(beta));
     }
     int axis = -1;
-    const auto& inputsSize = sModelInfo->getOperationInputsSize(mNnapiOperationIndex);
-    if (inputsSize == 3) axis = sModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 2);
+    const auto& inputsSize = mOpModelInfo->getOperationInputsSize(mNnapiOperationIndex);
+    if (inputsSize == 3) axis = mOpModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 2);
 
     const auto axisNode = createConstNode(ov::element::i32, {1}, convertToVector(axis));
 

--- a/ngraph_creator/operations/src/SpaceToBatch.cpp
+++ b/ngraph_creator/operations/src/SpaceToBatch.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-SpaceToBatch::SpaceToBatch(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+SpaceToBatch::SpaceToBatch(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 bool SpaceToBatch::validate() {
@@ -17,16 +17,16 @@ bool SpaceToBatch::validate() {
 
     if (inputRank != 4) return false;
 
-    auto& block_shape_OperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+    auto& block_shape_OperandIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 1);
     // TODO: Add Support for all_tensors_as_inputs
-    if (!sModelInfo->isOperandLifeTimeConst(block_shape_OperandIndex)) {
+    if (!mOpModelInfo->isOperandLifeTimeConst(block_shape_OperandIndex)) {
         ALOGE("%s Only Constant dimensions supported now", __func__);
         return false;
     }
 
-    auto pad_OperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 2);
+    auto pad_OperandIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 2);
     // TODO: Add Support for all_tensors_as_inputs
-    if (!sModelInfo->isOperandLifeTimeConst(pad_OperandIndex)) {
+    if (!mOpModelInfo->isOperandLifeTimeConst(pad_OperandIndex)) {
         ALOGE("%s Only Constant dimensions supported now", __func__);
         return false;
     }
@@ -38,22 +38,22 @@ bool SpaceToBatch::validate() {
 std::shared_ptr<ov::Node> SpaceToBatch::createNode() {
     int32_t layout = 0;
     bool useNchw = false;
-    const auto& inputsSize = sModelInfo->getOperationInputsSize(mNnapiOperationIndex);
+    const auto& inputsSize = mOpModelInfo->getOperationInputsSize(mNnapiOperationIndex);
 
     auto inputNode = getInputNode(0);
 
     auto& inDims = getInputOperandDimensions(0);
 
-    const auto& block_shape_OperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
-    auto block_shape = sModelInfo->GetConstVecOperand<int32_t>(block_shape_OperandIndex);
+    const auto& block_shape_OperandIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+    auto block_shape = mOpModelInfo->GetConstVecOperand<int32_t>(block_shape_OperandIndex);
 
     // Compensation for the shape to be same as the size of data input shape
     block_shape.insert(block_shape.begin(), 1);
     block_shape.insert(block_shape.begin(), 1);
 
-    const auto& pad_OperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 2);
+    const auto& pad_OperandIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 2);
     // Fetch the 2D pad as a 1D vector, and then split it into 2
-    auto pad_2d = sModelInfo->GetConstVecOperand<int32_t>(pad_OperandIndex);
+    auto pad_2d = mOpModelInfo->GetConstVecOperand<int32_t>(pad_OperandIndex);
     auto half_size = pad_2d.size() / 2;
     std::vector<int32_t> pad_0(half_size);
     std::vector<int32_t> pad_1(half_size);
@@ -74,7 +74,7 @@ std::shared_ptr<ov::Node> SpaceToBatch::createNode() {
     const auto pad_begin = createConstNode(ov::element::i64, {inDims.size()}, pad_0);
     const auto pad_end = createConstNode(ov::element::i64, {inDims.size()}, pad_1);
 
-    if (inputsSize == 4) layout = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 3);
+    if (inputsSize == 4) layout = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 3);
     if (layout) useNchw = true;
 
     if (!useNchw)  // No conversion needed if useNchw set

--- a/ngraph_creator/operations/src/SpaceToDepth.cpp
+++ b/ngraph_creator/operations/src/SpaceToDepth.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-SpaceToDepth::SpaceToDepth(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+SpaceToDepth::SpaceToDepth(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> SpaceToDepth::createNode() {
@@ -16,15 +16,15 @@ std::shared_ptr<ov::Node> SpaceToDepth::createNode() {
     std::shared_ptr<ov::Node> input;
     bool useNchw = false;
 
-    const auto& inputsSize = sModelInfo->getOperationInputsSize(mNnapiOperationIndex);
+    const auto& inputsSize = mOpModelInfo->getOperationInputsSize(mNnapiOperationIndex);
 
     if (inputsSize == 3) {
-        auto layout = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
+        auto layout = mOpModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
         if (layout) useNchw = true;
     }
 
     input = getInputNode(0);
-    auto block_size = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 1);
+    auto block_size = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 1);
 
     if (!useNchw)  // No conversion needed if useNchw set
         input = transpose(NHWC_NCHW, input);

--- a/ngraph_creator/operations/src/Split.cpp
+++ b/ngraph_creator/operations/src/Split.cpp
@@ -36,9 +36,10 @@ std::shared_ptr<ov::Node> Split::createNode() {
             outNode = std::make_shared<ov::opset3::Convert>(outputNode[i], ov::element::f16);
         } else if (checkInputOperandType(0, (int32_t)OperandType::TENSOR_INT32)) {
             outNode = std::make_shared<ov::opset3::Convert>(outputNode[i], ov::element::i32);
-        } else if (checkInputOperandType(0, (int32_t)OperandType::TENSOR_QUANT8_ASYMM) ||
-                   checkInputOperandType(0, (int32_t)OperandType::TENSOR_QUANT8_ASYMM_SIGNED)) {
+        } else if (checkInputOperandType(0, (int32_t)OperandType::TENSOR_QUANT8_ASYMM)) {
             outNode = std::make_shared<ov::opset3::Convert>(outputNode[i], ov::element::u8);
+        } else if (checkInputOperandType(0, (int32_t)OperandType::TENSOR_QUANT8_ASYMM_SIGNED)) {
+            outNode = std::make_shared<ov::opset3::Convert>(outputNode[i], ov::element::i8);
         }
 
         // auto outNode = outputNode[i].get_node_shared_ptr();

--- a/ngraph_creator/operations/src/Split.cpp
+++ b/ngraph_creator/operations/src/Split.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Split::Split(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Split::Split(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 void Split::connectOperationToGraph() { createNode(); }
@@ -19,15 +19,15 @@ std::shared_ptr<ov::Node> Split::createNode() {
 
     splitNode = getInputNode(0, false);
 
-    auto axis = sModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 1);
+    auto axis = mOpModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 1);
     auto axisNode = createConstNode(ov::element::i32, {}, convertToVector(axis));
-    auto numSplits = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
+    auto numSplits = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
 
     auto outputNode =
         std::make_shared<ov::opset3::Split>(splitNode, axisNode, numSplits)->outputs();
 
     for (size_t i = 0; i < numSplits; i++) {
-        auto outputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, i);
+        auto outputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, i);
         // TODO: remove this dummy convert
         std::shared_ptr<ov::Node> outNode;
         if (checkInputOperandType(0, (int32_t)OperandType::TENSOR_FLOAT32)) {

--- a/ngraph_creator/operations/src/Squeeze.cpp
+++ b/ngraph_creator/operations/src/Squeeze.cpp
@@ -7,19 +7,19 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Squeeze::Squeeze(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Squeeze::Squeeze(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 bool Squeeze::validate() {
     // TODO: Add Support for all_tensors_as_inputs
-    const auto& dimsOperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+    const auto& dimsOperandIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 1);
 
     // TODO: Support OmittedInput.
     // The empty 2nd argument in Squeeze op causes dynamic output
     // To add support, the dims will have to be calculated statically
-    if (sModelInfo->isOmittedInput(mNnapiOperationIndex, 1) ||
-        !sModelInfo->isOperandLifeTimeConst(dimsOperandIndex)) {
+    if (mOpModelInfo->isOmittedInput(mNnapiOperationIndex, 1) ||
+        !mOpModelInfo->isOperandLifeTimeConst(dimsOperandIndex)) {
         ALOGE("%s Only Constant dimensions supported now", __func__);
         return false;
     }
@@ -35,7 +35,7 @@ std::shared_ptr<ov::Node> Squeeze::createNode() {
 
     std::shared_ptr<ov::Node> dims;
 
-    if (!sModelInfo->isOmittedInput(mNnapiOperationIndex, 1))
+    if (!mOpModelInfo->isOmittedInput(mNnapiOperationIndex, 1))
         dims = getInputNode(1);
     else
         dims = createConstNode(ov::element::i32, {0}, std::vector<int64_t>{});

--- a/ngraph_creator/operations/src/Sub.cpp
+++ b/ngraph_creator/operations/src/Sub.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Sub::Sub(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Sub::Sub(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Sub::createNode() {
@@ -18,7 +18,7 @@ std::shared_ptr<ov::Node> Sub::createNode() {
     input1 = getInputNode(0);
     input2 = getInputNode(1);
 
-    auto activationFn = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
+    auto activationFn = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 2);
 
     auto subNode =
         std::make_shared<ov::opset3::Subtract>(input1, input2, ov::op::AutoBroadcastType::NUMPY);

--- a/ngraph_creator/operations/src/Tanh.cpp
+++ b/ngraph_creator/operations/src/Tanh.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Tanh::Tanh(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Tanh::Tanh(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 std::shared_ptr<ov::Node> Tanh::createNode() {

--- a/ngraph_creator/operations/src/TopkV2.cpp
+++ b/ngraph_creator/operations/src/TopkV2.cpp
@@ -7,8 +7,8 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-TopkV2::TopkV2(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+TopkV2::TopkV2(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 void TopkV2::connectOperationToGraph() { createNode(); }
@@ -19,7 +19,7 @@ std::shared_ptr<ov::Node> TopkV2::createNode() {
 
     input = getInputNode(0);
 
-    auto k = sModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 1);
+    auto k = mOpModelInfo->ParseOperationInput<int>(mNnapiOperationIndex, 1);
     int axis = -1;  // to find largest entries for the last dimension.
 
     auto k_node = createConstNode(ov::element::i32, {}, convertToVector(k));
@@ -29,7 +29,7 @@ std::shared_ptr<ov::Node> TopkV2::createNode() {
     auto outputNode = topk->outputs();
 
     for (int i = 0; i < 2; i++) {
-        auto outputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, i);
+        auto outputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, i);
         // TODO: remove this dummy convert
         std::shared_ptr<ov::Node> outNode;
         if (checkOutputOperandType(i, (int32_t)OperandType::TENSOR_FLOAT32)) {
@@ -48,7 +48,7 @@ std::shared_ptr<ov::Node> TopkV2::createNode() {
 
         mNgraphNodes->setOutputAtOperandIndex(outputIndex, outNode);
         ALOGD("%s Set Output index %d", __func__, outputIndex);
-        const auto op = sModelInfo->getOperand(outputIndex);
+        const auto op = mOpModelInfo->getOperand(outputIndex);
     }
     return nullptr;
 }

--- a/ngraph_creator/operations/src/Transpose.cpp
+++ b/ngraph_creator/operations/src/Transpose.cpp
@@ -7,15 +7,15 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-Transpose::Transpose(int operationIndex) : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+Transpose::Transpose(int operationIndex, GraphMetadata graphMetadata ) : OperationsBase(operationIndex, graphMetadata ) {
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 bool Transpose::validate() {
     // TODO: Add Support for all_tensors_as_inputs
-    const auto& dimsOperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+    const auto& dimsOperandIndex = mOpModelInfo->getOperationInput(mNnapiOperationIndex, 1);
     const auto& dims = getInputOperandDimensions(1);
-    if (!dims.empty() && dims[0] != 0 && !sModelInfo->isOperandLifeTimeConst(dimsOperandIndex)) {
+    if (!dims.empty() && dims[0] != 0 && !mOpModelInfo->isOperandLifeTimeConst(dimsOperandIndex)) {
         ALOGE("%s Only Constant dimensions supported now", __func__);
         return false;
     }

--- a/ngraph_creator/operations/src/UnidirectionalSequenceRNN.cpp
+++ b/ngraph_creator/operations/src/UnidirectionalSequenceRNN.cpp
@@ -9,9 +9,9 @@ namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-UnidirectionalSequenceRNN::UnidirectionalSequenceRNN(int operationIndex)
+UnidirectionalSequenceRNN::UnidirectionalSequenceRNN(int operationIndex, GraphMetadata graphMetadata)
     : OperationsBase(operationIndex) {
-    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+    mDefaultOutputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
 }
 
 void UnidirectionalSequenceRNN::connectOperationToGraph() { createNode(); }
@@ -26,8 +26,8 @@ std::shared_ptr<ov::Node> UnidirectionalSequenceRNN::createNode() {
     bias = getInputNode(3);
     initial_hidden_state = getInputNode(4);
 
-    auto activationFn = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 5);
-    auto isTimeMajor = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 6);
+    auto activationFn = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 5);
+    auto isTimeMajor = mOpModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 6);
 
     if (!isTimeMajor) {
         inputNode = transpose(BTS_TBS, inputNode);
@@ -84,14 +84,14 @@ std::shared_ptr<ov::Node> UnidirectionalSequenceRNN::createNode() {
         outputNode = transpose(BTS_TBS, outputNode);
     }
 
-    const auto& outputsSize = sModelInfo->getOperationOutputsSize(mNnapiOperationIndex);
+    const auto& outputsSize = mOpModelInfo->getOperationOutputsSize(mNnapiOperationIndex);
 
-    auto outputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+    auto outputIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
     mNgraphNodes->setOutputAtOperandIndex(outputIndex, outputNode);
     ALOGD("%s Set Output index %d", __func__, outputIndex);
 
     if (outputsSize == 2) {
-        auto hiddenStateIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 1);
+        auto hiddenStateIndex = mOpModelInfo->getOperationOutput(mNnapiOperationIndex, 1);
         mNgraphNodes->setOutputAtOperandIndex(hiddenStateIndex, hidden_state_output_last_timestep);
         ALOGD("%s Set Output index %d", __func__, hiddenStateIndex);
     }

--- a/ngraph_creator/src/OperationsFactory.cpp
+++ b/ngraph_creator/src/OperationsFactory.cpp
@@ -9,9 +9,8 @@ namespace nnhal {
 
 OperationsFactory::OperationsFactory(IntelDeviceType deviceType,
                                      std::shared_ptr<NnapiModelInfo> modelInfo,
-                                     std::shared_ptr<NgraphNodes> nodes) {
-    OperationsBase::sPluginType = deviceType;
-    OperationsBase::sModelInfo = modelInfo;
+                                     std::shared_ptr<NgraphNodes> nodes)
+    : mGraphMetadata {modelInfo, deviceType} {
     ALOGV("%s Constructed", __func__);
 }
 OperationsFactory::~OperationsFactory() { ALOGV("%s Destructed", __func__); }
@@ -19,167 +18,167 @@ std::shared_ptr<OperationsBase> OperationsFactory::getOperation(
     int operationIndex, const OperationType& operationType) {
     switch (operationType) {
         case OperationType::ABS:
-            return std::make_shared<Abs>(operationIndex);
+            return std::make_shared<Abs>(operationIndex, mGraphMetadata);
         case OperationType::ADD:
-            return std::make_shared<Add>(operationIndex);
+            return std::make_shared<Add>(operationIndex, mGraphMetadata);
         case OperationType::ARGMAX:
-            return std::make_shared<Argmax>(operationIndex);
+            return std::make_shared<Argmax>(operationIndex, mGraphMetadata);
         case OperationType::ARGMIN:
-            return std::make_shared<Argmin>(operationIndex);
+            return std::make_shared<Argmin>(operationIndex, mGraphMetadata);
         case OperationType::AVERAGE_POOL_2D:
-            return std::make_shared<AveragePool2D>(operationIndex);
+            return std::make_shared<AveragePool2D>(operationIndex, mGraphMetadata);
         case OperationType::BATCH_TO_SPACE_ND:
-            return std::make_shared<BatchToSpace>(operationIndex);
+            return std::make_shared<BatchToSpace>(operationIndex, mGraphMetadata);
         case OperationType::BIDIRECTIONAL_SEQUENCE_RNN:
-            return std::make_shared<BidirectionalSequenceRNN>(operationIndex);
+            return std::make_shared<BidirectionalSequenceRNN>(operationIndex, mGraphMetadata);
         case OperationType::CAST:
-            return std::make_shared<Cast>(operationIndex);
+            return std::make_shared<Cast>(operationIndex, mGraphMetadata);
         case OperationType::CHANNEL_SHUFFLE:
-            return std::make_shared<ChannelShuffle>(operationIndex);
+            return std::make_shared<ChannelShuffle>(operationIndex, mGraphMetadata);
         case OperationType::CONCATENATION:
-            return std::make_shared<Concat>(operationIndex);
+            return std::make_shared<Concat>(operationIndex, mGraphMetadata);
         case OperationType::CONV_2D:
-            return std::make_shared<Conv2d>(operationIndex);
+            return std::make_shared<Conv2d>(operationIndex, mGraphMetadata);
         case OperationType::DEPTH_TO_SPACE:
-            return std::make_shared<DepthToSpace>(operationIndex);
+            return std::make_shared<DepthToSpace>(operationIndex, mGraphMetadata);
         case OperationType::DEPTHWISE_CONV_2D:
-            return std::make_shared<DepthwiseConv2d>(operationIndex);
+            return std::make_shared<DepthwiseConv2d>(operationIndex, mGraphMetadata);
         case OperationType::DEQUANTIZE:
-            return std::make_shared<Dequantize>(operationIndex);
+            return std::make_shared<Dequantize>(operationIndex, mGraphMetadata);
         case OperationType::DIV:
-            return std::make_shared<Div>(operationIndex);
+            return std::make_shared<Div>(operationIndex, mGraphMetadata);
         case OperationType::EMBEDDING_LOOKUP:
-            return std::make_shared<EmbeddingLookup>(operationIndex);
+            return std::make_shared<EmbeddingLookup>(operationIndex, mGraphMetadata);
         case OperationType::EQUAL:
-            return std::make_shared<Equal>(operationIndex);
+            return std::make_shared<Equal>(operationIndex, mGraphMetadata);
         case OperationType::EXP:
-            return std::make_shared<Exp>(operationIndex);
+            return std::make_shared<Exp>(operationIndex, mGraphMetadata);
         case OperationType::EXPAND_DIMS:
-            return std::make_shared<ExpandDims>(operationIndex);
+            return std::make_shared<ExpandDims>(operationIndex, mGraphMetadata);
         case OperationType::FULLY_CONNECTED:
-            return std::make_shared<FullyConnected>(operationIndex);
+            return std::make_shared<FullyConnected>(operationIndex, mGraphMetadata);
         case OperationType::FLOOR:
-            return std::make_shared<Floor>(operationIndex);
+            return std::make_shared<Floor>(operationIndex, mGraphMetadata);
         case OperationType::GATHER:
-            return std::make_shared<Gather>(operationIndex);
+            return std::make_shared<Gather>(operationIndex, mGraphMetadata);
         case OperationType::GREATER:
-            return std::make_shared<Greater>(operationIndex);
+            return std::make_shared<Greater>(operationIndex, mGraphMetadata);
         case OperationType::GREATER_EQUAL:
-            return std::make_shared<GreaterEqual>(operationIndex);
+            return std::make_shared<GreaterEqual>(operationIndex, mGraphMetadata);
         case OperationType::GROUPED_CONV_2D:
-            return std::make_shared<GroupedConv2d>(operationIndex);
+            return std::make_shared<GroupedConv2d>(operationIndex, mGraphMetadata);
         case OperationType::HARD_SWISH:
-            return std::make_shared<HardSwish>(operationIndex);
+            return std::make_shared<HardSwish>(operationIndex, mGraphMetadata);
         case OperationType::INSTANCE_NORMALIZATION:
-            return std::make_shared<InstanceNormalization>(operationIndex);
+            return std::make_shared<InstanceNormalization>(operationIndex, mGraphMetadata);
         case OperationType::L2_POOL_2D:
-            return std::make_shared<L2Pooling2D>(operationIndex);
+            return std::make_shared<L2Pooling2D>(operationIndex, mGraphMetadata);
         case OperationType::L2_NORMALIZATION:
-            return std::make_shared<L2Normalization>(operationIndex);
+            return std::make_shared<L2Normalization>(operationIndex, mGraphMetadata);
         case OperationType::LSTM:
-            return std::make_shared<LSTM>(operationIndex);
+            return std::make_shared<LSTM>(operationIndex, mGraphMetadata);
         case OperationType::LESS:
-            return std::make_shared<Less>(operationIndex);
+            return std::make_shared<Less>(operationIndex, mGraphMetadata);
         case OperationType::LESS_EQUAL:
-            return std::make_shared<LessEqual>(operationIndex);
+            return std::make_shared<LessEqual>(operationIndex, mGraphMetadata);
         case OperationType::LOG_SOFTMAX:
-            return std::make_shared<LogSoftmax>(operationIndex);
+            return std::make_shared<LogSoftmax>(operationIndex, mGraphMetadata);
         case OperationType::LOG:
-            return std::make_shared<Log>(operationIndex);
+            return std::make_shared<Log>(operationIndex, mGraphMetadata);
         case OperationType::LOGICAL_AND:
-            return std::make_shared<LogicalAnd>(operationIndex);
+            return std::make_shared<LogicalAnd>(operationIndex, mGraphMetadata);
         case OperationType::LOGICAL_NOT:
-            return std::make_shared<LogicalNot>(operationIndex);
+            return std::make_shared<LogicalNot>(operationIndex, mGraphMetadata);
         case OperationType::LOGICAL_OR:
-            return std::make_shared<LogicalOr>(operationIndex);
+            return std::make_shared<LogicalOr>(operationIndex, mGraphMetadata);
         case OperationType::LOGISTIC:
-            return std::make_shared<Logistic>(operationIndex);
+            return std::make_shared<Logistic>(operationIndex, mGraphMetadata);
         case OperationType::MAXIMUM:
-            return std::make_shared<Maximum>(operationIndex);
+            return std::make_shared<Maximum>(operationIndex, mGraphMetadata);
         case OperationType::MAX_POOL_2D:
-            return std::make_shared<MaxPool2d>(operationIndex);
+            return std::make_shared<MaxPool2d>(operationIndex, mGraphMetadata);
         case OperationType::MEAN:
-            return std::make_shared<Mean>(operationIndex);
+            return std::make_shared<Mean>(operationIndex, mGraphMetadata);
         case OperationType::MINIMUM:
-            return std::make_shared<Minimum>(operationIndex);
+            return std::make_shared<Minimum>(operationIndex, mGraphMetadata);
         case OperationType::MUL:
-            return std::make_shared<Mul>(operationIndex);
+            return std::make_shared<Mul>(operationIndex, mGraphMetadata);
         case OperationType::NEG:
-            return std::make_shared<Neg>(operationIndex);
+            return std::make_shared<Neg>(operationIndex, mGraphMetadata);
         case OperationType::NOT_EQUAL:
-            return std::make_shared<NotEqual>(operationIndex);
+            return std::make_shared<NotEqual>(operationIndex, mGraphMetadata);
         case OperationType::PAD:
-            return std::make_shared<Pad>(operationIndex);
+            return std::make_shared<Pad>(operationIndex, mGraphMetadata);
         case OperationType::PAD_V2:
-            return std::make_shared<PadV2>(operationIndex);
+            return std::make_shared<PadV2>(operationIndex, mGraphMetadata);
         case OperationType::POW:
-            return std::make_shared<Pow>(operationIndex);
+            return std::make_shared<Pow>(operationIndex, mGraphMetadata);
         case OperationType::PRELU:
-            return std::make_shared<PRelu>(operationIndex);
+            return std::make_shared<PRelu>(operationIndex, mGraphMetadata);
         case OperationType::QUANTIZE:
-            return std::make_shared<Quantize>(operationIndex);
+            return std::make_shared<Quantize>(operationIndex, mGraphMetadata);
         case OperationType::REDUCE_ALL:
-            return std::make_shared<ReduceAll>(operationIndex);
+            return std::make_shared<ReduceAll>(operationIndex, mGraphMetadata);
         case OperationType::REDUCE_ANY:
-            return std::make_shared<ReduceAny>(operationIndex);
+            return std::make_shared<ReduceAny>(operationIndex, mGraphMetadata);
         case OperationType::REDUCE_MAX:
-            return std::make_shared<ReduceMax>(operationIndex);
+            return std::make_shared<ReduceMax>(operationIndex, mGraphMetadata);
         case OperationType::REDUCE_MIN:
-            return std::make_shared<ReduceMin>(operationIndex);
+            return std::make_shared<ReduceMin>(operationIndex, mGraphMetadata);
         case OperationType::REDUCE_PROD:
-            return std::make_shared<ReduceProd>(operationIndex);
+            return std::make_shared<ReduceProd>(operationIndex, mGraphMetadata);
         case OperationType::REDUCE_SUM:
-            return std::make_shared<ReduceSum>(operationIndex);
+            return std::make_shared<ReduceSum>(operationIndex, mGraphMetadata);
         case OperationType::RELU:
-            return std::make_shared<Relu>(operationIndex);
+            return std::make_shared<Relu>(operationIndex, mGraphMetadata);
         case OperationType::RELU1:
-            return std::make_shared<Relu1>(operationIndex);
+            return std::make_shared<Relu1>(operationIndex, mGraphMetadata);
         case OperationType::RELU6:
-            return std::make_shared<Relu6>(operationIndex);
+            return std::make_shared<Relu6>(operationIndex, mGraphMetadata);
         case OperationType::RESHAPE:
-            return std::make_shared<Reshape>(operationIndex);
+            return std::make_shared<Reshape>(operationIndex, mGraphMetadata);
         case OperationType::RNN:
-            return std::make_shared<RNN>(operationIndex);
+            return std::make_shared<RNN>(operationIndex, mGraphMetadata);
         case OperationType::ROI_ALIGN:
-            return std::make_shared<ROIAlign>(operationIndex);
+            return std::make_shared<ROIAlign>(operationIndex, mGraphMetadata);
         case OperationType::ROI_POOLING:
-            return std::make_shared<ROIPooling>(operationIndex);
+            return std::make_shared<ROIPooling>(operationIndex, mGraphMetadata);
         case OperationType::RSQRT:
-            return std::make_shared<RSQRT>(operationIndex);
+            return std::make_shared<RSQRT>(operationIndex, mGraphMetadata);
         case OperationType::RESIZE_BILINEAR:
-            return std::make_shared<ResizeBilinear>(operationIndex);
+            return std::make_shared<ResizeBilinear>(operationIndex, mGraphMetadata);
         case OperationType::RESIZE_NEAREST_NEIGHBOR:
-            return std::make_shared<ResizeNearestNeighbor>(operationIndex);
+            return std::make_shared<ResizeNearestNeighbor>(operationIndex, mGraphMetadata);
         case OperationType::SELECT:
-            return std::make_shared<Select>(operationIndex);
+            return std::make_shared<Select>(operationIndex, mGraphMetadata);
         case OperationType::SOFTMAX:
-            return std::make_shared<Softmax>(operationIndex);
+            return std::make_shared<Softmax>(operationIndex, mGraphMetadata);
         case OperationType::SPACE_TO_BATCH_ND:
-            return std::make_shared<SpaceToBatch>(operationIndex);
+            return std::make_shared<SpaceToBatch>(operationIndex, mGraphMetadata);
         case OperationType::SPACE_TO_DEPTH:
-            return std::make_shared<SpaceToDepth>(operationIndex);
+            return std::make_shared<SpaceToDepth>(operationIndex, mGraphMetadata);
         case OperationType::SQRT:
-            return std::make_shared<SQRT>(operationIndex);
+            return std::make_shared<SQRT>(operationIndex, mGraphMetadata);
         case OperationType::SIN:
-            return std::make_shared<Sin>(operationIndex);
+            return std::make_shared<Sin>(operationIndex, mGraphMetadata);
         case OperationType::SPLIT:
-            return std::make_shared<Split>(operationIndex);
+            return std::make_shared<Split>(operationIndex, mGraphMetadata);
         case OperationType::STRIDED_SLICE:
-            return std::make_shared<StridedSlice>(operationIndex);
+            return std::make_shared<StridedSlice>(operationIndex, mGraphMetadata);
         case OperationType::SQUEEZE:
-            return std::make_shared<Squeeze>(operationIndex);
+            return std::make_shared<Squeeze>(operationIndex, mGraphMetadata);
         case OperationType::SUB:
-            return std::make_shared<Sub>(operationIndex);
+            return std::make_shared<Sub>(operationIndex, mGraphMetadata);
         case OperationType::TANH:
-            return std::make_shared<Tanh>(operationIndex);
+            return std::make_shared<Tanh>(operationIndex, mGraphMetadata);
         case OperationType::TOPK_V2:
-            return std::make_shared<TopkV2>(operationIndex);
+            return std::make_shared<TopkV2>(operationIndex, mGraphMetadata);
         case OperationType::TRANSPOSE_CONV_2D:
-            return std::make_shared<TransposeConv2D>(operationIndex);
+            return std::make_shared<TransposeConv2D>(operationIndex, mGraphMetadata);
         case OperationType::TRANSPOSE:
-            return std::make_shared<Transpose>(operationIndex);
+            return std::make_shared<Transpose>(operationIndex, mGraphMetadata);
         case OperationType::UNIDIRECTIONAL_SEQUENCE_RNN:
-            return std::make_shared<UnidirectionalSequenceRNN>(operationIndex);
+            return std::make_shared<UnidirectionalSequenceRNN>(operationIndex, mGraphMetadata);
         default:
             ALOGE("%s Cannot identify OperationType %d", __func__, operationType);
             break;

--- a/ngraph_creator/src/OperationsFactory.cpp
+++ b/ngraph_creator/src/OperationsFactory.cpp
@@ -68,6 +68,8 @@ std::shared_ptr<OperationsBase> OperationsFactory::getOperation(
             return std::make_shared<GreaterEqual>(operationIndex);
         case OperationType::GROUPED_CONV_2D:
             return std::make_shared<GroupedConv2d>(operationIndex);
+        case OperationType::HARD_SWISH:
+            return std::make_shared<HardSwish>(operationIndex);
         case OperationType::INSTANCE_NORMALIZATION:
             return std::make_shared<InstanceNormalization>(operationIndex);
         case OperationType::L2_POOL_2D:

--- a/proto/nnhal_object_detection.proto
+++ b/proto/nnhal_object_detection.proto
@@ -27,6 +27,7 @@ service Detection {
   rpc getInferResult (RequestDataTensors) returns (ReplyDataTensors) {}
   rpc sendXml (stream RequestDataChunks) returns (ReplyStatus) {}
   rpc sendBin (stream RequestDataChunks) returns (ReplyStatus) {}
+  rpc loadModel(RequestString) returns (ReplyStatus) {}
   rpc prepare (RequestString) returns (ReplyStatus) {} //Placeholder for any future support : RequestString
 }
 
@@ -47,6 +48,25 @@ message DataTensor {
   bytes data = 1;
   string node_name = 2;
   repeated int32 tensor_shape = 3;
+  enum DATA_TYPE {
+    boolean = 0;
+    bf16 = 1;
+    f16 = 2;
+    f32 = 3;
+    f64 = 4;
+    i4 = 5;
+    i8 = 6;
+    i16 = 7;
+    i32 = 8;
+    i64 = 9;
+    u1 = 10;
+    u4 = 11;
+    u8 = 12;
+    u16 = 13;
+    u32 = 14;
+    u64 = 15;
+  }
+  DATA_TYPE data_type = 4;
 }
 
 // Reply message containing the Output Data Tensors(blobs)

--- a/proto/nnhal_object_detection.proto
+++ b/proto/nnhal_object_detection.proto
@@ -1,16 +1,18 @@
-// Copyright 2015 gRPC authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+* Copyright (c) 2022 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 syntax = "proto3";
 
@@ -29,15 +31,20 @@ service Detection {
   rpc sendBin (stream RequestDataChunks) returns (ReplyStatus) {}
   rpc loadModel(RequestString) returns (ReplyStatus) {}
   rpc prepare (RequestString) returns (ReplyStatus) {} //Placeholder for any future support : RequestString
+  rpc release (RequestString) returns (ReplyStatus) {}
 }
 
+message Token {
+  uint32 data = 1;
+}
 
 message RequestDataChunks {
   bytes data = 1;
+  Token token = 2;
 }
 
 message RequestString {
-  string value = 1;
+  Token token = 1;
 }
 message ReplyStatus {
   bool status = 1;
@@ -77,4 +84,5 @@ message ReplyDataTensors {
 // Request message containing the Input Data Tensors(blobs)
 message RequestDataTensors {
   repeated DataTensor data_tensors = 1;
+  Token token = 2;
 }


### PR DESCRIPTION
Modified nn-hal to improve memory utilization and scores on the Ai_Benchmark app.
Improvement includes:
         - better memory usage while doing parallel inference
         - more operations enabled/added with float 16 support
         - offload to remote infer if available
                 -  offload to remote only if the model is non-quant type
                 -  for now, remote-infer is only supported if nn-api calls execute Synchronously
         - enable parallel remote inference
         - supports dynamic input shapes and data-types for remote infer
         
Tracked-On: OAM-109729