### PR TITLE
Avoid accessing member of empty smart pointer

### DIFF
--- a/BasePreparedModel.cpp
+++ b/BasePreparedModel.cpp
@@ -532,7 +532,8 @@ static std::tuple<ErrorStatus, hidl_vec<V1_2::OutputShape>, Timing> executeSynch
             }
         }
 
-        if (!preparedModel->mRemoteCheck || !preparedModel->mDetectionClient->get_status()) {
+        if (!preparedModel->mRemoteCheck || !preparedModel->mDetectionClient ||
+            !preparedModel->mDetectionClient->get_status()) {
             ov::Tensor destTensor;
             try {
                 if (!plugin->queryState()) {


### PR DESCRIPTION
The get_status call on the mDetectionClient pointer is being done without a validation done on the pointer itself.

Adding a null check for preparedModel->mDetectionClient before calling preparedModel->mDetectionClient->get_status.

Tracked-On: OAM-118484